### PR TITLE
Enable docker cache mount in GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -3,8 +3,7 @@ on:
     push:
         branches:
             - main
-            - deploy
-            - docker-build-switch
+            - github-docker-cache
 
 jobs:
     build:
@@ -16,6 +15,31 @@ jobs:
             -
                 name: Set up Buildx
                 uses: docker/setup-buildx-action@v2
+
+            # Docker layer cache works almost automatically, but cache mounts need more setup
+            -
+                name: Cache
+                uses: actions/cache@v3
+                id: cache
+                with:
+                  path: |
+                      root-gradle
+                      root-cache
+                      app-gradle
+                  key: frontend
+
+            -
+                name: inject cache mounts into docker
+                uses: reproducible-containers/buildkit-cache-dance@v3.1.0
+                with:
+                    cache-map: |
+                        {
+                            "root-gradle": "/root/.gradle",
+                            "root-cache": "/root/.cache",
+                            "app-gradle": "/app/.gradle"
+                        }
+                    skip-extraction: ${{ steps.cache.outputs.cache-hit }}
+
             -
                 name: Login to GitHub Container Registry
                 uses: docker/login-action@v3
@@ -23,6 +47,12 @@ jobs:
                     registry: ghcr.io
                     username: ${{ github.actor }}
                     password: ${{ secrets.GITHUB_TOKEN }}
+
+            # exposes ACTIONS_CACHE_URL and ACTIONS_RUNTIME_TOKEN
+            # see https://docs.docker.com/build/cache/backends/gha/
+            -
+                name: Expose
+                uses: crazy-max/ghaction-github-runtime@v3
             -
                 run: ./deploy/build.sh
 

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -6,5 +6,10 @@
     <codeStyleSettings language="kotlin">
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </codeStyleSettings>
+    <codeStyleSettings language="yaml">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="4" />
+      </indentOptions>
+    </codeStyleSettings>
   </code_scheme>
 </component>

--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -2,12 +2,17 @@
 
 set -ex
 
-source $(dirname "$0")/vars.sh
-
 cd $(dirname "$0")/..
 
-docker build \
+source $(dirname "$0")/vars.sh
+
+# It seems we can always specify GitHub Actions caching
+# and if it's not available it will fall back to local caching.
+docker buildx build \
     --file deploy/Dockerfile \
     --tag $TAG \
     --progress=plain \
+    --cache-to type=gha,mode=max,scope=frontend \
+    --cache-from type=gha,scope=frontend \
+    --push \
     .

--- a/site/gradlew
+++ b/site/gradlew
@@ -1,6 +1,5 @@
 #!/bin/sh
 
-#
 # Copyright © 2015-2021 the original authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Layer cache is still better I think but this will work for all our gradle needs without thinking too hard. 