### PR TITLE
Fix imports

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,5 @@
 kotlin.code.style=official
 org.gradle.caching=true
 org.gradle.configuration-cache=true
+org.gradle.jvmargs=-Xmx16g -Xms1g -XX:MaxMetaspaceSize=512m
+kotlin.daemon.jvmargs=-Xmx16g -Xms512m

--- a/server/src/main/kotlin/js/loader/DefaultJsLoader.kt
+++ b/server/src/main/kotlin/js/loader/DefaultJsLoader.kt
@@ -15,13 +15,11 @@ class DefaultJsLoader(
             return null
         }
 
+        val accessPolicy = accessPolicyEvaluator.eval(url)
         val connection = url.openConnection()
         val lastModified = connection.lastModified
         // immediately read into memory to prevent desync
         val content = connection.getInputStream().readBytes()
-
-        val filename = path.substringAfterLast('/')
-        val accessPolicy = accessPolicyEvaluator.eval(content.inputStream().reader(), filename)
 
         val cleanPath = path.replace(Regex("\\W"), "")
         val eTag = "$cleanPath-$lastModified"


### PR DESCRIPTION
This allows javascript imports to be resolved again when evaluating the code on the server to get the access policy of the script.

There is still a cross-domain cookie issue which prevents the genius model from working.