### PR TITLE
Fix bundling shared private modules

### DIFF
--- a/backend/src/main/kotlin/js/JsAccessPolicyEvaluator.kt
+++ b/backend/src/main/kotlin/js/JsAccessPolicyEvaluator.kt
@@ -20,6 +20,9 @@ val getScriptAccessPolicy = JsAccessPolicyEvaluator { url ->
     val source = Source.newBuilder("js", url).build()
     val output = context.eval(source)
     val jsAccessPolicy = output.getMember("accessPolicy")
+    if (jsAccessPolicy == null) {
+        throw Exception("Can't serve javascript module because it does not have an exported member accessPolicy: $url")
+    }
     val jsonAccessPolicy = jsAccessPolicy.invokeMember("get").invokeMember("toJson")
 
     println("JSON accessPolicy of $url: $jsonAccessPolicy")

--- a/deploy/backend/Dockerfile
+++ b/deploy/backend/Dockerfile
@@ -1,11 +1,10 @@
 # Build artifact
 FROM eclipse-temurin:24 AS builder
 
-WORKDIR /app
-
-# Npm to install Rollup
 RUN apt-get update && apt-get install -y \
-        npm
+    npm
+
+WORKDIR /app
 
 # Create a cache layer with dependencies
 # Need to copy all the gradle subprojects

--- a/site/rollup/package-lock.json
+++ b/site/rollup/package-lock.json
@@ -6,8 +6,31 @@
         "": {
             "dependencies": {
                 "@rollup/plugin-dynamic-import-vars": "^2.1.5",
-                "@rollup/plugin-node-resolve": "^16.0.1",
-                "rollup": "^4.40.2"
+                "@rollup/plugin-node-resolve": "^16.0.3",
+                "core-js": "^3.48.0",
+                "glob": "^13.0.0",
+                "rollup": "^4.57.1"
+            }
+        },
+        "node_modules/@isaacs/balanced-match": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+            "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
+            "license": "MIT",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@isaacs/brace-expansion": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+            "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+            "license": "MIT",
+            "dependencies": {
+                "@isaacs/balanced-match": "^4.0.1"
+            },
+            "engines": {
+                "node": "20 || >=22"
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
@@ -76,9 +99,9 @@
             }
         },
         "node_modules/@rollup/plugin-node-resolve": {
-            "version": "16.0.1",
-            "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.1.tgz",
-            "integrity": "sha512-tk5YCxJWIG81umIvNkSod2qK5KyQW19qcBF/B78n1bjtOON6gzKoVeSzAE8yHCZEDmqkHKkxplExA8KzdJLJpA==",
+            "version": "16.0.3",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-16.0.3.tgz",
+            "integrity": "sha512-lUYM3UBGuM93CnMPG1YocWu7X802BrNF3jW2zny5gQyLQgRFJhV1Sq0Zi74+dh/6NBx1DxFC4b4GXg9wUCG5Qg==",
             "license": "MIT",
             "dependencies": {
                 "@rollup/pluginutils": "^5.0.1",
@@ -122,9 +145,9 @@
             }
         },
         "node_modules/@rollup/rollup-android-arm-eabi": {
-            "version": "4.40.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.40.2.tgz",
-            "integrity": "sha512-JkdNEq+DFxZfUwxvB58tHMHBHVgX23ew41g1OQinthJ+ryhdRk67O31S7sYw8u2lTjHUPFxwar07BBt1KHp/hg==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+            "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
             "cpu": [
                 "arm"
             ],
@@ -135,9 +158,9 @@
             ]
         },
         "node_modules/@rollup/rollup-android-arm64": {
-            "version": "4.40.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.40.2.tgz",
-            "integrity": "sha512-13unNoZ8NzUmnndhPTkWPWbX3vtHodYmy+I9kuLxN+F+l+x3LdVF7UCu8TWVMt1POHLh6oDHhnOA04n8oJZhBw==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+            "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
             "cpu": [
                 "arm64"
             ],
@@ -148,9 +171,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-arm64": {
-            "version": "4.40.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.40.2.tgz",
-            "integrity": "sha512-Gzf1Hn2Aoe8VZzevHostPX23U7N5+4D36WJNHK88NZHCJr7aVMG4fadqkIf72eqVPGjGc0HJHNuUaUcxiR+N/w==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+            "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
             "cpu": [
                 "arm64"
             ],
@@ -161,9 +184,9 @@
             ]
         },
         "node_modules/@rollup/rollup-darwin-x64": {
-            "version": "4.40.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.40.2.tgz",
-            "integrity": "sha512-47N4hxa01a4x6XnJoskMKTS8XZ0CZMd8YTbINbi+w03A2w4j1RTlnGHOz/P0+Bg1LaVL6ufZyNprSg+fW5nYQQ==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+            "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
             "cpu": [
                 "x64"
             ],
@@ -174,9 +197,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-arm64": {
-            "version": "4.40.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.40.2.tgz",
-            "integrity": "sha512-8t6aL4MD+rXSHHZUR1z19+9OFJ2rl1wGKvckN47XFRVO+QL/dUSpKA2SLRo4vMg7ELA8pzGpC+W9OEd1Z/ZqoQ==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+            "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
             "cpu": [
                 "arm64"
             ],
@@ -187,9 +210,9 @@
             ]
         },
         "node_modules/@rollup/rollup-freebsd-x64": {
-            "version": "4.40.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.40.2.tgz",
-            "integrity": "sha512-C+AyHBzfpsOEYRFjztcYUFsH4S7UsE9cDtHCtma5BK8+ydOZYgMmWg1d/4KBytQspJCld8ZIujFMAdKG1xyr4Q==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+            "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
             "cpu": [
                 "x64"
             ],
@@ -200,9 +223,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-            "version": "4.40.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.40.2.tgz",
-            "integrity": "sha512-de6TFZYIvJwRNjmW3+gaXiZ2DaWL5D5yGmSYzkdzjBDS3W+B9JQ48oZEsmMvemqjtAFzE16DIBLqd6IQQRuG9Q==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+            "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
             "cpu": [
                 "arm"
             ],
@@ -213,9 +236,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-            "version": "4.40.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.40.2.tgz",
-            "integrity": "sha512-urjaEZubdIkacKc930hUDOfQPysezKla/O9qV+O89enqsqUmQm8Xj8O/vh0gHg4LYfv7Y7UsE3QjzLQzDYN1qg==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+            "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
             "cpu": [
                 "arm"
             ],
@@ -226,9 +249,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-gnu": {
-            "version": "4.40.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.40.2.tgz",
-            "integrity": "sha512-KlE8IC0HFOC33taNt1zR8qNlBYHj31qGT1UqWqtvR/+NuCVhfufAq9fxO8BMFC22Wu0rxOwGVWxtCMvZVLmhQg==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+            "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
             "cpu": [
                 "arm64"
             ],
@@ -239,9 +262,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-arm64-musl": {
-            "version": "4.40.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.40.2.tgz",
-            "integrity": "sha512-j8CgxvfM0kbnhu4XgjnCWJQyyBOeBI1Zq91Z850aUddUmPeQvuAy6OiMdPS46gNFgy8gN1xkYyLgwLYZG3rBOg==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+            "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
             "cpu": [
                 "arm64"
             ],
@@ -251,10 +274,10 @@
                 "linux"
             ]
         },
-        "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-            "version": "4.40.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.40.2.tgz",
-            "integrity": "sha512-Ybc/1qUampKuRF4tQXc7G7QY9YRyeVSykfK36Y5Qc5dmrIxwFhrOzqaVTNoZygqZ1ZieSWTibfFhQ5qK8jpWxw==",
+        "node_modules/@rollup/rollup-linux-loong64-gnu": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+            "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
             "cpu": [
                 "loong64"
             ],
@@ -264,10 +287,36 @@
                 "linux"
             ]
         },
-        "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-            "version": "4.40.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.40.2.tgz",
-            "integrity": "sha512-3FCIrnrt03CCsZqSYAOW/k9n625pjpuMzVfeI+ZBUSDT3MVIFDSPfSUgIl9FqUftxcUXInvFah79hE1c9abD+Q==",
+        "node_modules/@rollup/rollup-linux-loong64-musl": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+            "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+            "cpu": [
+                "loong64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+            "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@rollup/rollup-linux-ppc64-musl": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+            "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
             "cpu": [
                 "ppc64"
             ],
@@ -278,9 +327,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-            "version": "4.40.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.40.2.tgz",
-            "integrity": "sha512-QNU7BFHEvHMp2ESSY3SozIkBPaPBDTsfVNGx3Xhv+TdvWXFGOSH2NJvhD1zKAT6AyuuErJgbdvaJhYVhVqrWTg==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+            "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
             "cpu": [
                 "riscv64"
             ],
@@ -291,9 +340,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-riscv64-musl": {
-            "version": "4.40.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.40.2.tgz",
-            "integrity": "sha512-5W6vNYkhgfh7URiXTO1E9a0cy4fSgfE4+Hl5agb/U1sa0kjOLMLC1wObxwKxecE17j0URxuTrYZZME4/VH57Hg==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+            "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
             "cpu": [
                 "riscv64"
             ],
@@ -304,9 +353,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-s390x-gnu": {
-            "version": "4.40.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.40.2.tgz",
-            "integrity": "sha512-B7LKIz+0+p348JoAL4X/YxGx9zOx3sR+o6Hj15Y3aaApNfAshK8+mWZEf759DXfRLeL2vg5LYJBB7DdcleYCoQ==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+            "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
             "cpu": [
                 "s390x"
             ],
@@ -317,9 +366,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-gnu": {
-            "version": "4.40.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.40.2.tgz",
-            "integrity": "sha512-lG7Xa+BmBNwpjmVUbmyKxdQJ3Q6whHjMjzQplOs5Z+Gj7mxPtWakGHqzMqNER68G67kmCX9qX57aRsW5V0VOng==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+            "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
             "cpu": [
                 "x64"
             ],
@@ -330,9 +379,9 @@
             ]
         },
         "node_modules/@rollup/rollup-linux-x64-musl": {
-            "version": "4.40.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.40.2.tgz",
-            "integrity": "sha512-tD46wKHd+KJvsmije4bUskNuvWKFcTOIM9tZ/RrmIvcXnbi0YK/cKS9FzFtAm7Oxi2EhV5N2OpfFB348vSQRXA==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+            "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
             "cpu": [
                 "x64"
             ],
@@ -342,10 +391,36 @@
                 "linux"
             ]
         },
+        "node_modules/@rollup/rollup-openbsd-x64": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+            "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ]
+        },
+        "node_modules/@rollup/rollup-openharmony-arm64": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+            "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
         "node_modules/@rollup/rollup-win32-arm64-msvc": {
-            "version": "4.40.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.40.2.tgz",
-            "integrity": "sha512-Bjv/HG8RRWLNkXwQQemdsWw4Mg+IJ29LK+bJPW2SCzPKOUaMmPEppQlu/Fqk1d7+DX3V7JbFdbkh/NMmurT6Pg==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+            "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
             "cpu": [
                 "arm64"
             ],
@@ -356,9 +431,9 @@
             ]
         },
         "node_modules/@rollup/rollup-win32-ia32-msvc": {
-            "version": "4.40.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.40.2.tgz",
-            "integrity": "sha512-dt1llVSGEsGKvzeIO76HToiYPNPYPkmjhMHhP00T9S4rDern8P2ZWvWAQUEJ+R1UdMWJ/42i/QqJ2WV765GZcA==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+            "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
             "cpu": [
                 "ia32"
             ],
@@ -368,10 +443,23 @@
                 "win32"
             ]
         },
+        "node_modules/@rollup/rollup-win32-x64-gnu": {
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+            "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ]
+        },
         "node_modules/@rollup/rollup-win32-x64-msvc": {
-            "version": "4.40.2",
-            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.40.2.tgz",
-            "integrity": "sha512-bwspbWB04XJpeElvsp+DCylKfF4trJDa2Y9Go8O6A7YLX2LIKGcNK/CYImJN6ZP4DcuOHB4Utl3iCbnR62DudA==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+            "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
             "cpu": [
                 "x64"
             ],
@@ -382,9 +470,9 @@
             ]
         },
         "node_modules/@types/estree": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
-            "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
             "license": "MIT"
         },
         "node_modules/@types/resolve": {
@@ -412,6 +500,17 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/core-js": {
+            "version": "3.48.0",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
+            "integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/core-js"
             }
         },
         "node_modules/deepmerge": {
@@ -489,6 +588,23 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/glob": {
+            "version": "13.0.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
+            "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.1.1",
+                "minipass": "^7.1.2",
+                "path-scurry": "^2.0.0"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/glob-parent": {
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -564,6 +680,15 @@
                 "node": ">=0.12.0"
             }
         },
+        "node_modules/lru-cache": {
+            "version": "11.2.5",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+            "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
         "node_modules/magic-string": {
             "version": "0.30.17",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -607,11 +732,51 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/minimatch": {
+            "version": "10.1.1",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+            "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "@isaacs/brace-expansion": "^5.0.0"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/minipass": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            }
+        },
         "node_modules/path-parse": {
             "version": "1.0.7",
             "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "license": "MIT"
+        },
+        "node_modules/path-scurry": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
+            "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
         },
         "node_modules/picomatch": {
             "version": "4.0.2",
@@ -646,12 +811,12 @@
             "license": "MIT"
         },
         "node_modules/resolve": {
-            "version": "1.22.10",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-            "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+            "version": "1.22.11",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+            "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
             "license": "MIT",
             "dependencies": {
-                "is-core-module": "^2.16.0",
+                "is-core-module": "^2.16.1",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
@@ -676,12 +841,12 @@
             }
         },
         "node_modules/rollup": {
-            "version": "4.40.2",
-            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.40.2.tgz",
-            "integrity": "sha512-tfUOg6DTP4rhQ3VjOO6B4wyrJnGOX85requAXvqYTHsOgb2TFJdZ3aWpT8W2kPoypSGP7dZUyzxJ9ee4buM5Fg==",
+            "version": "4.57.1",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+            "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
             "license": "MIT",
             "dependencies": {
-                "@types/estree": "1.0.7"
+                "@types/estree": "1.0.8"
             },
             "bin": {
                 "rollup": "dist/bin/rollup"
@@ -691,26 +856,31 @@
                 "npm": ">=8.0.0"
             },
             "optionalDependencies": {
-                "@rollup/rollup-android-arm-eabi": "4.40.2",
-                "@rollup/rollup-android-arm64": "4.40.2",
-                "@rollup/rollup-darwin-arm64": "4.40.2",
-                "@rollup/rollup-darwin-x64": "4.40.2",
-                "@rollup/rollup-freebsd-arm64": "4.40.2",
-                "@rollup/rollup-freebsd-x64": "4.40.2",
-                "@rollup/rollup-linux-arm-gnueabihf": "4.40.2",
-                "@rollup/rollup-linux-arm-musleabihf": "4.40.2",
-                "@rollup/rollup-linux-arm64-gnu": "4.40.2",
-                "@rollup/rollup-linux-arm64-musl": "4.40.2",
-                "@rollup/rollup-linux-loongarch64-gnu": "4.40.2",
-                "@rollup/rollup-linux-powerpc64le-gnu": "4.40.2",
-                "@rollup/rollup-linux-riscv64-gnu": "4.40.2",
-                "@rollup/rollup-linux-riscv64-musl": "4.40.2",
-                "@rollup/rollup-linux-s390x-gnu": "4.40.2",
-                "@rollup/rollup-linux-x64-gnu": "4.40.2",
-                "@rollup/rollup-linux-x64-musl": "4.40.2",
-                "@rollup/rollup-win32-arm64-msvc": "4.40.2",
-                "@rollup/rollup-win32-ia32-msvc": "4.40.2",
-                "@rollup/rollup-win32-x64-msvc": "4.40.2",
+                "@rollup/rollup-android-arm-eabi": "4.57.1",
+                "@rollup/rollup-android-arm64": "4.57.1",
+                "@rollup/rollup-darwin-arm64": "4.57.1",
+                "@rollup/rollup-darwin-x64": "4.57.1",
+                "@rollup/rollup-freebsd-arm64": "4.57.1",
+                "@rollup/rollup-freebsd-x64": "4.57.1",
+                "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+                "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+                "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+                "@rollup/rollup-linux-arm64-musl": "4.57.1",
+                "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+                "@rollup/rollup-linux-loong64-musl": "4.57.1",
+                "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+                "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+                "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+                "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+                "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+                "@rollup/rollup-linux-x64-gnu": "4.57.1",
+                "@rollup/rollup-linux-x64-musl": "4.57.1",
+                "@rollup/rollup-openbsd-x64": "4.57.1",
+                "@rollup/rollup-openharmony-arm64": "4.57.1",
+                "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+                "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+                "@rollup/rollup-win32-x64-gnu": "4.57.1",
+                "@rollup/rollup-win32-x64-msvc": "4.57.1",
                 "fsevents": "~2.3.2"
             }
         },

--- a/site/rollup/package.json
+++ b/site/rollup/package.json
@@ -4,7 +4,9 @@
     },
     "dependencies": {
         "@rollup/plugin-dynamic-import-vars": "^2.1.5",
-        "@rollup/plugin-node-resolve": "^16.0.1",
-        "rollup": "^4.40.2"
+        "@rollup/plugin-node-resolve": "^16.0.3",
+        "core-js": "^3.48.0",
+        "glob": "^13.0.0",
+        "rollup": "^4.57.1"
     }
 }

--- a/site/rollup/rollup.config.mjs
+++ b/site/rollup/rollup.config.mjs
@@ -2,6 +2,8 @@ import dynamicImportVars from '@rollup/plugin-dynamic-import-vars';
 import nodeResolve from "@rollup/plugin-node-resolve";
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
+import { globSync } from 'glob';
+import "core-js/stable/array/to-sorted.js"
 
 const rootProjectDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..")
 
@@ -9,13 +11,28 @@ const rootProjectDir = path.resolve(path.dirname(fileURLToPath(import.meta.url))
  * @type {import('rollup').RollupOptions}
  */
 export default {
-    input: path.resolve(rootProjectDir, "build/js/packages/zenmo-site/kotlin/zenmo-site/main.export.mjs"),
+    // Create an entry chunk for every Kotlin file with @JsExport annotation.
+    // This ensures that those exports are present in the final bundles.
+    // Rollup will de-duplicate across entry chunks.
+    input: globSync(path.resolve(rootProjectDir, "build/js/packages/zenmo-site/kotlin/zenmo-site/**/*.export.mjs")),
     output: {
         dir: path.resolve(rootProjectDir, "site/build/rollup"),
         format: "module",
-        entryFileNames: "[name].mjs",
+        entryFileNames: chunkInfo => {
+            if (chunkInfo.facadeModuleId.endsWith("main.export.mjs")) {
+                return "main.export.mjs"
+            }
+            return moduleIdToChunkName(chunkInfo.facadeModuleId) + "-[hash].mjs"
+        },
         chunkFileNames: "[name]-[hash].mjs",
         sourcemap: "hidden",
+        // Create a chunk for every module (= Kotlin file) which exports "accessPolicy".
+        // (it is currently equivalent to check for the file extension *.export.mjs.)
+        manualChunks: (moduleId, meta) => {
+            const rootImporter = getFirstImporterWithAccessPolicy(moduleId, meta.getModuleInfo)
+            return moduleIdToChunkName(rootImporter)
+        },
+        minifyInternalExports: false,
     },
     preserveEntrySignatures: "allow-extension",
     plugins: [
@@ -26,4 +43,98 @@ export default {
         }),
         dynamicImportVars(),
     ]
+}
+
+/**
+ * This function finds the takes a module and searches it's importers
+ * to find a module which has an Access Policy.
+ * 
+ * @param {string} moduleId
+ * @param {import('rollup').GetModuleInfo} getModuleInfo
+ * 
+ * @returns string
+ */
+function getFirstImporterWithAccessPolicy(moduleId, getModuleInfo) {
+    const importersWithAccessPolicy = breadthFirstSearch(
+        moduleId,
+        moduleId => getModuleInfo(moduleId).importers,
+        moduleId => getModuleInfo(moduleId).exports.includes("accessPolicy")
+    )
+
+    if (!importersWithAccessPolicy.length === 0) {
+        throw Error(`accessPolicy not found in importers of ${moduleId}`)
+    }
+
+    // Selecting the shortest module ensures that we prefer the public main.export.mjs entrypoint
+    // rather than an entrypoint which is protected by role-based access control.
+    // It would be more reliable to inspect the accessPolicy variable content but this is more complicated.
+    return shortest(importersWithAccessPolicy)
+}
+
+/**
+ * Name chunks so they're not all called "ProtectedComponent".
+ * 
+ * @param {string} moduleId 
+ * @returns string
+ */
+function moduleIdToChunkName(moduleId) {
+    const matches = moduleId.match(/(?<parentDir>[^\/]*)\/(?<name>[^\/]*)\.export\.mjs$/)
+    if (!matches || matches.length === 0) {
+        throw Error(`file does not match expected format: ${moduleId}`)
+    }
+
+    if (matches.groups.name === "main") {
+        return "main.export"
+    }
+
+    if (matches.groups.name === "ProtectedComponent") {
+        return matches.groups.parentDir
+    }
+
+    return matches.groups.name
+}
+
+/**
+ * @param {Array<string>} stringArray 
+ * @returns string
+ */
+function shortest(stringArray) {
+    return stringArray.toSorted((left, right) => left.length - right.length)[0]
+}
+
+/**
+ * Use a breadth-first search because it's good at dealing with cyclical dependencies.
+ *
+ * @template T
+ * @param {T} startNode
+ * @param {(T) => T[]} getNeighbors
+ * @param {(T) => boolean} predicate
+ * @returns {T[]}
+ */
+function breadthFirstSearch(startNode, getNeighbors, predicate) {
+    const visited = new Set()
+    const queue = [startNode]
+    const result = []
+
+    visited.add(startNode)
+
+    while (queue.length > 0) {
+        const node = queue.shift();
+
+        // Check if this node matches our target
+        if (predicate(node)) {
+            result.push(node);
+        }
+
+        // Visit all neighbors
+        const neighbors = getNeighbors(node);
+        for (const neighbor of neighbors) {
+            if (!visited.has(neighbor)) {
+                visited.add(neighbor);
+                queue.push(neighbor);
+            }
+        }
+    }
+
+    return result;
 }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/AppEntry.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/AppEntry.kt
@@ -24,10 +24,6 @@ import org.w3c.dom.Window
 
 private const val COLOR_MODE_KEY = "zenmo:colorMode"
 
-@OptIn(ExperimentalJsExport::class)
-@JsExport
-val accessPolicy = AccessPolicy.Public()
-
 @InitSilk
 fun initColorMode(ctx: InitSilkContext) {
     ctx.config.initialColorMode = ColorMode.LIGHT


### PR DESCRIPTION
Problem: when two private modules both import a dependency which is not in the public chunk, Rollup creates a new chunk. This chunk however does not have export an accessPolicy thus the backend refuses to serve it. This currently breaks the Drechtsteden models.

Solution: specify that every module should belong to a chunk which exports "accessPolicy" throught the "manualChunks" option.

New Problem: accessPolicy export is renamed for these combined private chunks.

New Solution: specify all Kotlin files with @JsExport as entrypoints for Rollup. Rollup will appearantly also deduplicate across entrypoints.