### PR TITLE
Fix JS cache headers

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -58,3 +58,8 @@ tasks.register<Copy>("copyJsResources") {
 tasks.named("processResources") {
     dependsOn("copyJsResources")
 }
+
+tasks.withType<AbstractArchiveTask>().configureEach {
+    // We use these timestamps to set the Last-Modified header
+    isPreserveFileTimestamps = true
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Gradle 8 -> 9 fixated file timestamps to make builds more reproducable. This reverts to the old behavior. Also changes the ETag logic so it depends on file content and not modified date.

Fixes #412