### PR TITLE
Update Kobweb, remove protocol in links

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 jetbrains-compose = "1.7.1"
-kobweb = "0.23.0"
+kobweb = "0.23.3"
 kotlin = "2.2.21"
 kotlinx-serialization = "1.8.1"
 

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/components/widgets/UnknownDomain.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/components/widgets/UnknownDomain.kt
@@ -21,12 +21,11 @@ fun UnknownDomain(
             nlText = "Onbekend Domein: $domain"
         )
 
-        val protocol = window.location.protocol
         PrimaryButton(
             enText = "Go to main Lux site",
             nlText = "Ga naar de hoofd Lux site",
             onClick = {
-                window.location.href = "${protocol}//${SiteGlobals.LUX_DOMAIN}"
+                window.location.href = "//${SiteGlobals.LUX_DOMAIN}"
             }
         )
     }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/core/model/subdomain/SubdomainTwinModel.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/core/model/subdomain/SubdomainTwinModel.kt
@@ -11,5 +11,5 @@ import kotlinx.browser.window
  */
 sealed interface SubdomainTwinModel : Subdomain, TwinModelCard {
     override val url: String
-        get() = "${window.location.protocol}//${subdomain}.${SiteGlobals.LUX_DOMAIN}"
+        get() = "//${subdomain}.${SiteGlobals.LUX_DOMAIN}"
 }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/theme/typography/core/ResponsiveScale.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/theme/typography/core/ResponsiveScale.kt
@@ -7,12 +7,14 @@ data class ResponsiveScale(
     val sm: Double,
     val md: Double,
     val lg: Double,
-    val xl: Double
+    val xl: Double,
+    val xxl: Double = xl,
 ) {
     fun at(bp: Breakpoint) = when (bp) {
         Breakpoint.ZERO, Breakpoint.SM -> sm
         Breakpoint.MD -> md
         Breakpoint.LG -> lg
         Breakpoint.XL -> xl
+        Breakpoint.XXL -> xxl
     }.cssRem
 }


### PR DESCRIPTION
It was fixed in Kobweb that we can now use links starting with // to use the same protocol (http or https) when we link within the site.