### PR TITLE
text for business parks model pages

### DIFF
--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/components/BusinessParkModelPageText.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/components/BusinessParkModelPageText.kt
@@ -1,0 +1,40 @@
+package com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components
+
+import androidx.compose.runtime.Composable
+import com.zenmo.web.zenmo.components.widgets.LangText
+import org.jetbrains.compose.web.dom.Div
+import org.jetbrains.compose.web.dom.P
+
+
+@Composable
+fun BusinessParkModelPageText() {
+    Div {
+        P {
+            LangText(
+                en = """
+                    The energy twin for business parks supports businesses in launching energy hubs. With the energy 
+                    twin, entrepreneurs and advisors gain insights into renewable energy measures, the implementation 
+                    of energy management systems, and the setup of energy hubs. 
+                """.trimIndent(),
+                nl = """
+                    De energy twin voor bedrijventerreinen ondersteunt bedrijven bij het opstarten van energy hubs. Met 
+                    de energy twin krijgen ondernemers en adviseurs inzicht in de verduurzaming van bedrijven, de 
+                    implementatie van energiemanagementsystemen en de opzet van energy hubs.
+                """.trimIndent()
+            )
+        }
+
+        P {
+            LangText(
+                en = """
+                    Thanks to these energy hubs with collective grid connection contracts, businesses can expand and 
+                    become more sustainable, despite grid congestion.
+                """.trimIndent(),
+                nl = """
+                    Dankzij deze energy hubs en groepscontracten kunnen bedrijven uitbreiden en verduurzamen, ondanks 
+                    netcongestie.
+                """.trimIndent()
+            )
+        }
+    }
+}

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/components/DrechtstedenTwinModelPage.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/components/DrechtstedenTwinModelPage.kt
@@ -1,9 +1,14 @@
 package com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components
 
 import androidx.compose.runtime.Composable
+import com.varabyte.kobweb.compose.foundation.layout.Column
+import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.modifiers.fillMaxWidth
+import com.varabyte.kobweb.compose.ui.modifiers.gap
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.components.PrivateTwinModelPage
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.DrechtstedenTwinModel
 import com.zenmo.web.zenmo.domains.lux.widgets.headings.HeaderText
+import org.jetbrains.compose.web.css.cssRem
 
 @Composable
 fun DrechtstedenTwinModelPage(
@@ -15,11 +20,16 @@ fun DrechtstedenTwinModelPage(
     entryPoint = twin.entryPoint,
     imageUrl = twin.imageUrl,
     introContent = {
-        HeaderText(
-            enText = twin.label.en,
-            nlText = twin.label.nl,
-        )
-        introContent()
+        Column(
+            Modifier.fillMaxWidth()
+                .gap(1.cssRem)
+        ) {
+            HeaderText(
+                enText = twin.label.en,
+                nlText = twin.label.nl,
+            )
+            introContent()
+        }
     },
     mediaContent = mediaContent,
     footerContent = footerContent,

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/AmbachtsePage.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/AmbachtsePage.kt
@@ -1,12 +1,11 @@
 package com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.pages.businessparks
 
 import androidx.compose.runtime.Composable
-import com.zenmo.web.zenmo.components.widgets.LangText
 import com.zenmo.web.zenmo.domains.lux.subdomains.components.ZenmoModellerProfileCard
+import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.BusinessParkModelPageText
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.DrechtstedenTwinModelPage
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.ModelInDevelopmentInfoWidget
 import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
-import org.jetbrains.compose.web.dom.P
 
 
 @Composable
@@ -14,24 +13,7 @@ fun AmbachtsePage() {
     ModelInDevelopmentInfoWidget()
     DrechtstedenTwinModelPage(
         twin = ambachtseZoom,
-        introContent = {
-            P {
-                LangText(
-                    en = """
-                Below you can find the digital twin for the sustainability of the Ambachtse zoom business park. 
-                The companies on this business park are exploring whether they can share energy and invest in 
-                sustainable technologies together. The digital twin will help in designing these sustainable energy 
-                systems and making the right decisions.
-            """.trimIndent(),
-                    nl = """
-                Bekijk hieronder  de digital twin voor de verduurzaming van bedrijventerrein Ambachtse zoom. De 
-                bedrijven op dit bedrijventerrein zijn aan het onderzoeken of ze samen energie kunnen delen en 
-                investeren in duurzame technieken. De digital twin zal helpen bij het ontwerpen van deze duurzame 
-                energiesystemen en het maken van de juiste beslissingen.
-            """.trimIndent(),
-                )
-            }
-        },
+        introContent = { BusinessParkModelPageText() },
         footerContent = {
             ZenmoModellerProfileCard(ZenmoTeam.GILLIS)
         }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/AmstelwijckPage.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/AmstelwijckPage.kt
@@ -1,12 +1,11 @@
 package com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.pages.businessparks
 
 import androidx.compose.runtime.Composable
-import com.zenmo.web.zenmo.components.widgets.LangText
 import com.zenmo.web.zenmo.domains.lux.subdomains.components.ZenmoModellerProfileCard
+import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.BusinessParkModelPageText
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.DrechtstedenTwinModelPage
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.ModelInDevelopmentInfoWidget
 import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
-import org.jetbrains.compose.web.dom.P
 
 
 @Composable
@@ -14,24 +13,7 @@ fun AmstelwijckPage() {
     ModelInDevelopmentInfoWidget()
     DrechtstedenTwinModelPage(
         twin = amstelwijckBusinesspark,
-        introContent = {
-            P {
-                LangText(
-                    en = """
-                Below you can view the digital twin for the sustainability of the Amstelwijck Businesspark. 
-                The companies on this business park are exploring whether they can share energy and invest in 
-                sustainable technologies together. The digital twin will assist in designing these sustainable 
-                energy systems and making the right decisions.
-            """.trimIndent(),
-                    nl = """
-                Bekijk hieronder  de digital twin voor de verduurzaming van bedrijventerrein Amstelwijck Businesspark. 
-                De bedrijven op dit bedrijventerrein zijn aan het onderzoeken of ze samen energie kunnen delen en 
-                investeren in duurzame technieken. De digital twin zal helpen bij het ontwerpen van deze duurzame 
-                energiesystemen en het maken van de juiste beslissingen.
-            """.trimIndent(),
-                )
-            }
-        },
+        introContent = { BusinessParkModelPageText() },
         footerContent = {
             ZenmoModellerProfileCard(ZenmoTeam.GILLIS)
         }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/AntoniapolderPage.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/AntoniapolderPage.kt
@@ -1,12 +1,11 @@
 package com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.pages.businessparks
 
 import androidx.compose.runtime.Composable
-import com.zenmo.web.zenmo.components.widgets.LangText
 import com.zenmo.web.zenmo.domains.lux.subdomains.components.ZenmoModellerProfileCard
+import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.BusinessParkModelPageText
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.DrechtstedenTwinModelPage
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.ModelInDevelopmentInfoWidget
 import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
-import org.jetbrains.compose.web.dom.P
 
 
 @Composable
@@ -14,24 +13,7 @@ fun AntoniapolderPage() {
     ModelInDevelopmentInfoWidget()
     DrechtstedenTwinModelPage(
         twin = antoniapolder,
-        introContent = {
-            P {
-                LangText(
-                    en = """
-                Below you can view the digital twin for the sustainability of the Antoniapolder and Groenoord business 
-                parks in Hendrik-Ido-Ambacht. The companies in this business park are exploring whether they can share 
-                energy and invest in sustainable technologies together. The digital twin will assist in designing these 
-                sustainable energy systems and making the right decisions.
-            """.trimIndent(),
-                    nl = """
-                Bekijk hieronder  de digital twin voor de verduurzaming van bedrijventerrein Antoniapolder en Groenoord 
-                in Hendrik-Ido-Ambacht. De bedrijven op dit bedrijventerrein zijn aan het onderzoeken of ze samen 
-                energie kunnen delen en investeren in duurzame technieken. De digital twin zal helpen bij het ontwerpen 
-                van deze duurzame energiesystemen en het maken van de juiste beslissingen.
-            """.trimIndent(),
-                )
-            }
-        },
+        introContent = { BusinessParkModelPageText() },
         footerContent = {
             ZenmoModellerProfileCard(ZenmoTeam.NAUD_LOOMANS)
         }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/BakesteinPage.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/BakesteinPage.kt
@@ -1,12 +1,11 @@
 package com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.pages.businessparks
 
 import androidx.compose.runtime.Composable
-import com.zenmo.web.zenmo.components.widgets.LangText
 import com.zenmo.web.zenmo.domains.lux.subdomains.components.ZenmoModellerProfileCard
+import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.BusinessParkModelPageText
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.DrechtstedenTwinModelPage
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.ModelInDevelopmentInfoWidget
 import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
-import org.jetbrains.compose.web.dom.P
 
 
 @Composable
@@ -17,24 +16,7 @@ fun BakesteinPage() {
     )
     DrechtstedenTwinModelPage(
         twin = bakestein,
-        introContent = {
-            P {
-                LangText(
-                    en = """
-                Below you can view the digital twin for the sustainability of the Bakestein business park in Zwijndrecht. 
-                The companies on this business park are exploring whether they can share energy and invest in sustainable 
-                technologies together. The digital twin will assist in designing these sustainable energy systems and 
-                making the right decisions.
-            """.trimIndent(),
-                    nl = """
-                Bekijk hieronder  de digital twin voor de verduurzaming van bedrijventerrein Bakestein in Zwijndrecht. 
-                De bedrijven op dit bedrijventerrein onderzoeken of ze samen energie kunnen delen en investeren in 
-                duurzame technieken. De digital twin zal helpen bij het ontwerpen van deze duurzame energiesystemen en 
-                het maken van de juiste beslissingen.
-            """.trimIndent(),
-                )
-            }
-        },
+        introContent = { BusinessParkModelPageText() },
         footerContent = {
             ZenmoModellerProfileCard(ZenmoTeam.GILLIS)
         }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/DeGeerPage.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/DeGeerPage.kt
@@ -1,12 +1,11 @@
 package com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.pages.businessparks
 
 import androidx.compose.runtime.Composable
-import com.zenmo.web.zenmo.components.widgets.LangText
 import com.zenmo.web.zenmo.domains.lux.subdomains.components.ZenmoModellerProfileCard
+import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.BusinessParkModelPageText
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.DrechtstedenTwinModelPage
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.ModelInDevelopmentInfoWidget
 import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
-import org.jetbrains.compose.web.dom.P
 
 
 @Composable
@@ -18,24 +17,7 @@ fun DeGeerPage() {
 
     DrechtstedenTwinModelPage(
         twin = deGeer,
-        introContent = {
-            P {
-                LangText(
-                    en = """
-                Below you can view the digital twin for the sustainability of business park De Geer in Zwijndrecht. The 
-                companies on this business park are exploring whether they can share energy and invest in sustainable 
-                technologies together. The digital twin will assist in designing these sustainable energy systems and 
-                making the right decisions.
-            """.trimIndent(),
-                    nl = """
-                Bekijk hieronder  de digital twin voor de verduurzaming van bedrijventerrein De Geer in Zwijndrecht. De 
-                bedrijven op dit bedrijventerrein onderzoeken of ze samen energie kunnen delen en investeren in 
-                duurzame technieken. De digital twin zal helpen bij het ontwerpen van deze duurzame energiesystemen en 
-                het maken van de juiste beslissingen.
-            """.trimIndent(),
-                )
-            }
-        },
+        introContent = { BusinessParkModelPageText() },
         footerContent = {
             ZenmoModellerProfileCard(ZenmoTeam.GILLIS)
         }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/DeStaartPage.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/DeStaartPage.kt
@@ -1,12 +1,11 @@
 package com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.pages.businessparks
 
 import androidx.compose.runtime.Composable
-import com.zenmo.web.zenmo.components.widgets.LangText
 import com.zenmo.web.zenmo.domains.lux.subdomains.components.ZenmoModellerProfileCard
+import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.BusinessParkModelPageText
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.DrechtstedenTwinModelPage
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.ModelInDevelopmentInfoWidget
 import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
-import org.jetbrains.compose.web.dom.P
 
 
 @Composable
@@ -14,23 +13,7 @@ fun DeStaartPage() {
     ModelInDevelopmentInfoWidget()
     DrechtstedenTwinModelPage(
         twin = deStaart,
-        introContent = {
-            P {
-                LangText(
-                    en = """
-                Below you can view the digital twin for the sustainability of business park De Staart. The companies 
-                located here are exploring how they can share energy and invest in sustainable technologies together. 
-                The digital twin will assist in designing these sustainable energy systems and making informed decisions.
-            """.trimIndent(),
-                    nl = """
-                Bekijk hieronder  de digital twin voor de verduurzaming van bedrijventerrein De Staart. De bedrijven op 
-                dit bedrijventerrein zijn aan het onderzoeken of ze samen energie kunnen delen en investeren in 
-                duurzame technieken. De digital twin zal helpen bij het ontwerpen van deze duurzame energiesystemen en 
-                het maken van de juiste beslissingen.
-            """.trimIndent(),
-                )
-            }
-        },
+        introContent = { BusinessParkModelPageText() },
         footerContent = {
             ZenmoModellerProfileCard(ZenmoTeam.GILLIS)
         }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/DordtseKilIIIPage.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/DordtseKilIIIPage.kt
@@ -1,12 +1,11 @@
 package com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.pages.businessparks
 
 import androidx.compose.runtime.Composable
-import com.zenmo.web.zenmo.components.widgets.LangText
 import com.zenmo.web.zenmo.domains.lux.subdomains.components.ZenmoModellerProfileCard
+import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.BusinessParkModelPageText
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.DrechtstedenTwinModelPage
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.ModelInDevelopmentInfoWidget
 import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
-import org.jetbrains.compose.web.dom.P
 
 
 @Composable
@@ -17,24 +16,7 @@ fun DordtseKilIIIPage() {
     )
     DrechtstedenTwinModelPage(
         twin = dordtseKil34,
-        introContent = {
-            P {
-                LangText(
-                    en = """
-                Below you can find the digital twin for the sustainability of business park Dordtse Kil 3&4 in 
-                Dordrecht. The companies on this business park are investigating whether they can share energy 
-                together and invest in sustainable technologies. The digital twin will help in designing these 
-                sustainable energy systems and making the right decisions.
-            """.trimIndent(),
-                    nl = """
-                Bekijk hieronder  de digital twin voor de verduurzaming van bedrijventerrein Dordtse Kil 3&4 in 
-                Dordrecht. De bedrijven op dit bedrijventerrein zijn aan het onderzoeken of ze samen energie kunnen 
-                delen en investeren in duurzame technieken. De digital twin zal helpen bij het ontwerpen van deze 
-                duurzame energiesystemen en het maken van de juiste beslissingen.
-            """.trimIndent(),
-                )
-            }
-        },
+        introContent = { BusinessParkModelPageText() },
         footerContent = {
             ZenmoModellerProfileCard(ZenmoTeam.ATE)
         }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/DordtseKilIPage.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/DordtseKilIPage.kt
@@ -1,12 +1,11 @@
 package com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.pages.businessparks
 
 import androidx.compose.runtime.Composable
-import com.zenmo.web.zenmo.components.widgets.LangText
 import com.zenmo.web.zenmo.domains.lux.subdomains.components.ZenmoModellerProfileCard
+import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.BusinessParkModelPageText
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.DrechtstedenTwinModelPage
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.ModelInDevelopmentInfoWidget
 import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
-import org.jetbrains.compose.web.dom.P
 
 
 @Composable
@@ -17,24 +16,7 @@ fun DordtseKilIPage() {
     )
     DrechtstedenTwinModelPage(
         twin = dordtseKil12AmstelwijckWest,
-        introContent = {
-            P {
-                LangText(
-                    en = """
-                Below you can find the digital twin for the sustainability of business parks Dordtse Kil 1&2 and 
-                Amstelwijck West in Dordrecht. The companies on these business parks are exploring whether they can 
-                share energy and invest in sustainable technologies together. The digital twin will assist in designing 
-                these sustainable energy systems and making the right decisions.
-            """.trimIndent(),
-                    nl = """
-                Bekijk hieronder  de digital twin voor de verduurzaming van bedrijventerreinen Dordtse Kil 1&2 en 
-                Amstelwijck West in Dordrecht. De bedrijven op deze bedrijventerreinen zijn aan het onderzoeken of ze 
-                samen energie kunnen delen en investeren in duurzame technieken. De digital twin zal helpen bij het 
-                ontwerpen van deze duurzame energiesystemen en het maken van de juiste beslissingen.
-            """.trimIndent(),
-                )
-            }
-        },
+        introContent = { BusinessParkModelPageText() },
         footerContent = {
             ZenmoModellerProfileCard(ZenmoTeam.ATE)
         }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/LeerparkPage.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/LeerparkPage.kt
@@ -1,12 +1,11 @@
 package com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.pages.businessparks
 
 import androidx.compose.runtime.Composable
-import com.zenmo.web.zenmo.components.widgets.LangText
 import com.zenmo.web.zenmo.domains.lux.subdomains.components.ZenmoModellerProfileCard
+import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.BusinessParkModelPageText
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.DrechtstedenTwinModelPage
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.ModelInDevelopmentInfoWidget
 import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
-import org.jetbrains.compose.web.dom.P
 
 
 @Composable
@@ -15,24 +14,7 @@ fun LeerparkPage() {
 
     DrechtstedenTwinModelPage(
         twin = leerpark,
-        introContent = {
-            P {
-                LangText(
-                    en = """
-                Below you can view the digital twin for the sustainability of the Leerpark business park. The companies 
-                in this business park are exploring whether they can share energy and invest in sustainable technologies 
-                together. The digital twin will assist in designing these sustainable energy systems and making the 
-                right decisions.
-            """.trimIndent(),
-                    nl = """
-                Bekijk hieronder  de digital twin voor de verduurzaming van bedrijventerrein Leerpark. De bedrijven op 
-                dit bedrijventerrein zijn aan het onderzoeken of ze samen energie kunnen delen en investeren in 
-                duurzame technieken. De digital twin zal helpen bij het ontwerpen van deze duurzame energiesystemen en 
-                het maken van de juiste beslissingen.
-            """.trimIndent(),
-                )
-            }
-        },
+        introContent = { BusinessParkModelPageText() },
         footerContent = {
             ZenmoModellerProfileCard(ZenmoTeam.GILLIS)
         }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/LindtPage.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/LindtPage.kt
@@ -1,12 +1,11 @@
 package com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.pages.businessparks
 
 import androidx.compose.runtime.Composable
-import com.zenmo.web.zenmo.components.widgets.LangText
 import com.zenmo.web.zenmo.domains.lux.subdomains.components.ZenmoModellerProfileCard
+import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.BusinessParkModelPageText
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.DrechtstedenTwinModelPage
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.ModelInDevelopmentInfoWidget
 import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
-import org.jetbrains.compose.web.dom.P
 
 
 @Composable
@@ -14,24 +13,7 @@ fun LindtPage() {
     ModelInDevelopmentInfoWidget()
     DrechtstedenTwinModelPage(
         twin = grooteLindtV2,
-        introContent = {
-            P {
-                LangText(
-                    en = """
-                Below you can find the digital twin for the sustainability of the Groote Lindt business park in 
-                Zwijndrecht. The companies on this business park are exploring whether they can share energy and 
-                invest in sustainable technologies together. The digital twin will help in designing these sustainable 
-                energy systems and making the right decisions.
-            """.trimIndent(),
-                    nl = """
-                Bekijk hieronder  de digital twin voor de verduurzaming van bedrijventerrein Groote Lindt in 
-                Zwijndrecht. De bedrijven op dit bedrijventerrein zijn aan het onderzoeken of ze samen energie kunnen 
-                delen en investeren in duurzame technieken. De digital twin zal helpen bij het ontwerpen van deze 
-                duurzame energiesystemen en het maken van de juiste beslissingen.
-            """.trimIndent(),
-                )
-            }
-        },
+        introContent = { BusinessParkModelPageText() },
         footerContent = {
             ZenmoModellerProfileCard(ZenmoTeam.GILLIS)
         }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/NieuweWegPage.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/NieuweWegPage.kt
@@ -1,12 +1,11 @@
 package com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.pages.businessparks
 
 import androidx.compose.runtime.Composable
-import com.zenmo.web.zenmo.components.widgets.LangText
 import com.zenmo.web.zenmo.domains.lux.subdomains.components.ZenmoModellerProfileCard
+import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.BusinessParkModelPageText
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.DrechtstedenTwinModelPage
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.ModelInDevelopmentInfoWidget
 import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
-import org.jetbrains.compose.web.dom.P
 
 
 @Composable
@@ -14,24 +13,7 @@ fun NieuweWegPage() {
     ModelInDevelopmentInfoWidget()
     DrechtstedenTwinModelPage(
         twin = nieuweWeg,
-        introContent = {
-            P {
-                LangText(
-                    en = """
-                Below you can find the digital twin for the sustainability of the Nieuwe Weg business park in 
-                Hardinxveld-Giesendam. The companies on this business park are exploring whether they can share energy 
-                and invest in sustainable technologies together. The digital twin will help in designing these sustainable 
-                energy systems and making the right decisions.
-            """.trimIndent(),
-                    nl = """
-                Bekijk hieronder  de digital twin voor de verduurzaming van bedrijventerrein Nieuwe Weg in 
-                Hardinxveld-Giesendam. De bedrijven op dit bedrijventerrein zijn aan het onderzoeken of ze samen 
-                energie kunnen delen en investeren in duurzame technieken. De digital twin zal helpen bij het ontwerpen 
-                van deze duurzame energiesystemen en het maken van de juiste beslissingen.
-            """.trimIndent(),
-                )
-            }
-        },
+        introContent = { BusinessParkModelPageText() },
         footerContent = {
             ZenmoModellerProfileCard(ZenmoTeam.GILLIS)
         }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/PapendrechtPage.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/PapendrechtPage.kt
@@ -1,12 +1,11 @@
 package com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.pages.businessparks
 
 import androidx.compose.runtime.Composable
-import com.zenmo.web.zenmo.components.widgets.LangText
 import com.zenmo.web.zenmo.domains.lux.subdomains.components.ZenmoModellerProfileCard
+import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.BusinessParkModelPageText
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.DrechtstedenTwinModelPage
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.ModelInDevelopmentInfoWidget
 import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
-import org.jetbrains.compose.web.dom.P
 
 
 @Composable
@@ -14,24 +13,7 @@ fun PapendrechtPage() {
     ModelInDevelopmentInfoWidget()
     DrechtstedenTwinModelPage(
         twin = papendrechtOosteind,
-        introContent = {
-            P {
-                LangText(
-                    en = """
-                Below you can find the digital twin for the sustainability of the Papendrecht Oosteind business park. 
-                The companies on this business park are exploring whether they can share energy and invest in 
-                sustainable technologies together. The digital twin will help in designing these sustainable energy 
-                systems and making the right decisions.
-            """.trimIndent(),
-                    nl = """
-                Bekijk hieronder  de digital twin voor de verduurzaming van bedrijventerrein Papendrecht Oosteind. De 
-                bedrijven op dit bedrijventerrein zijn aan het onderzoeken of ze samen energie kunnen delen en 
-                investeren in duurzame technieken. De digital twin zal helpen bij het ontwerpen van deze duurzame 
-                energiesystemen en het maken van de juiste beslissingen.
-            """.trimIndent(),
-                )
-            }
-        },
+        introContent = { BusinessParkModelPageText() },
         footerContent = {
             ZenmoModellerProfileCard(ZenmoTeam.GILLIS)
         }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/SliedrechtPage.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/SliedrechtPage.kt
@@ -1,12 +1,11 @@
 package com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.pages.businessparks
 
 import androidx.compose.runtime.Composable
-import com.zenmo.web.zenmo.components.widgets.LangText
 import com.zenmo.web.zenmo.domains.lux.subdomains.components.ZenmoModellerProfileCard
+import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.BusinessParkModelPageText
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.DrechtstedenTwinModelPage
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.ModelInDevelopmentInfoWidget
 import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
-import org.jetbrains.compose.web.dom.P
 
 
 @Composable
@@ -14,24 +13,7 @@ fun SliedrechtPage() {
     ModelInDevelopmentInfoWidget()
     DrechtstedenTwinModelPage(
         twin = sliedrechtBusinesspark,
-        introContent = {
-            P {
-                LangText(
-                    en = """
-                Below you can view the digital twin for the sustainability of the business parks Nijverwaard, 
-                Stationspark, and Kwadrant in Sliedrecht. The companies on these business parks are exploring 
-                whether they can share energy and invest in sustainable technologies together. The digital twin will 
-                assist in designing these sustainable energy systems and making the right decisions.
-            """.trimIndent(),
-                    nl = """
-                Bekijk hieronder  de digital twin voor de verduurzaming van bedrijventerreinen Nijverwaard, 
-                Stationspark en Kwadrant in Sliedrecht. De bedrijven op deze bedrijventerreinen zijn aan het 
-                onderzoeken of ze samen energie kunnen delen en investeren in duurzame technieken. De digital twin zal 
-                helpen bij het ontwerpen van deze duurzame energiesystemen en het maken van de juiste beslissingen.
-            """.trimIndent(),
-                )
-            }
-        },
+        introContent = { BusinessParkModelPageText() },
         footerContent = {
             ZenmoModellerProfileCard(ZenmoTeam.GILLIS)
         }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/drechtstedenBusinessParkModels.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/drechtstedenBusinessParkModels.kt
@@ -7,7 +7,7 @@ import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtstede
 val ambachtseZoom =
     DrechtstedenTwinModel(
         projectPath = "/ambachtsezoom",
-        label = LocalizedText(nl = "Digital twin Ambachtse Zoom"),
+        label = LocalizedText(nl = "Energy Twin Ambachtse Zoom"),
         applicationArea = DrechtstedenProjectArea.BUSINESS_PARKS,
         entryPoint = "drechtsteden/businessparks/ambachtse",
         imageUrl = "/lux/images/drechtsteden/business-parks/ambachtsezoom.png",
@@ -16,7 +16,7 @@ val ambachtseZoom =
 val amstelwijckBusinesspark =
     DrechtstedenTwinModel(
         projectPath = "/amstelwijckbusinesspark",
-        label = LocalizedText(nl = "Digital twin Amstelwijck Businesspark"),
+        label = LocalizedText(nl = "Energy Twin Amstelwijck Businesspark"),
         applicationArea = DrechtstedenProjectArea.BUSINESS_PARKS,
         entryPoint = "drechtsteden/businessparks/amstelwijck",
         imageUrl = "/lux/images/drechtsteden/business-parks/Amstelwijck_businesspark_foto.png",
@@ -25,7 +25,7 @@ val amstelwijckBusinesspark =
 val antoniapolder =
     DrechtstedenTwinModel(
         projectPath = "/antoniapolder",
-        label = LocalizedText(nl = "Digital twin Antoniapolder"),
+        label = LocalizedText(nl = "Energy Twin Antoniapolder"),
         applicationArea = DrechtstedenProjectArea.BUSINESS_PARKS,
         entryPoint = "drechtsteden/businessparks/antoniapolder",
         imageUrl = "/lux/images/drechtsteden/business-parks/antoniapolder.png",
@@ -34,7 +34,7 @@ val antoniapolder =
 val bakestein =
     DrechtstedenTwinModel(
         projectPath = "/bakestein",
-        label = LocalizedText(nl = "Digital twin Bakestein"),
+        label = LocalizedText(nl = "Energy Twin Bakestein"),
         applicationArea = DrechtstedenProjectArea.BUSINESS_PARKS,
         entryPoint = "drechtsteden/businessparks/bakestein",
         imageUrl = "/lux/images/drechtsteden/business-parks/bakestein.png",
@@ -43,7 +43,7 @@ val bakestein =
 val deGeer =
     DrechtstedenTwinModel(
         projectPath = "/degeer",
-        label = LocalizedText(nl = "Digital twin De Geer"),
+        label = LocalizedText(nl = "Energy Twin De Geer"),
         applicationArea = DrechtstedenProjectArea.BUSINESS_PARKS,
         entryPoint = "drechtsteden/businessparks/degeer",
         imageUrl = "/lux/images/drechtsteden/business-parks/de_geer.png",
@@ -52,7 +52,7 @@ val deGeer =
 val deStaart =
     DrechtstedenTwinModel(
         projectPath = "/destaart",
-        label = LocalizedText(nl = "Digital twin De Staart"),
+        label = LocalizedText(nl = "Energy Twin De Staart"),
         applicationArea = DrechtstedenProjectArea.BUSINESS_PARKS,
         entryPoint = "drechtsteden/businessparks/destaart",
         imageUrl = "/lux/images/drechtsteden/business-parks/de-staart.jpg",
@@ -61,7 +61,7 @@ val deStaart =
 val dordtseKil12AmstelwijckWest =
     DrechtstedenTwinModel(
         projectPath = "/dordtsekil12amstelwijckwest",
-        label = LocalizedText(nl = "Digital twin Dordtse Kil I & II en Amstelwijck West"),
+        label = LocalizedText(nl = "Energy Twin Dordtse Kil I & II en Amstelwijck West"),
         applicationArea = DrechtstedenProjectArea.BUSINESS_PARKS,
         entryPoint = "drechtsteden/businessparks/dordtseamstelwijck",
         imageUrl = "/lux/images/drechtsteden/business-parks/dordtsekil12enAmstelwijckWest_foto.png",
@@ -70,7 +70,7 @@ val dordtseKil12AmstelwijckWest =
 val dordtseKil34 =
     DrechtstedenTwinModel(
         projectPath = "/dordtsekil34",
-        label = LocalizedText(nl = "Digital twin Dordtse Kil III & IV"),
+        label = LocalizedText(nl = "Energy Twin Dordtse Kil III & IV"),
         applicationArea = DrechtstedenProjectArea.BUSINESS_PARKS,
         entryPoint = "drechtsteden/businessparks/dordtse",
         imageUrl = "/lux/images/drechtsteden/business-parks/dordtsekil34.png",
@@ -79,7 +79,7 @@ val dordtseKil34 =
 val grooteLindtV2 =
     DrechtstedenTwinModel(
         projectPath = "/grootelindtv2",
-        label = LocalizedText(nl = "Digital twin Groote Lindt v2"),
+        label = LocalizedText(nl = "Energy Twin Groote Lindt v2"),
         applicationArea = DrechtstedenProjectArea.BUSINESS_PARKS,
         entryPoint = "drechtsteden/businessparks/groote",
         imageUrl = "/lux/images/drechtsteden/business-parks/Groote-Lindt.png",
@@ -88,7 +88,7 @@ val grooteLindtV2 =
 val leerpark =
     DrechtstedenTwinModel(
         projectPath = "/leerpark",
-        label = LocalizedText(nl = "Digital twin Leerpark"),
+        label = LocalizedText(nl = "Energy Twin Leerpark"),
         applicationArea = DrechtstedenProjectArea.BUSINESS_PARKS,
         entryPoint = "drechtsteden/businessparks/leerpark",
         imageUrl = "/lux/images/drechtsteden/business-parks/Leerpark_foto.png",
@@ -97,7 +97,7 @@ val leerpark =
 val nieuweWeg =
     DrechtstedenTwinModel(
         projectPath = "/nieuweweg",
-        label = LocalizedText(nl = "Digital twin Nieuwe Weg"),
+        label = LocalizedText(nl = "Energy Twin Nieuwe Weg"),
         applicationArea = DrechtstedenProjectArea.BUSINESS_PARKS,
         entryPoint = "drechtsteden/businessparks/nieuweweg",
         imageUrl = "/lux/images/drechtsteden/business-parks/FeaturedImageNieuweWegPagina.png",
@@ -106,7 +106,7 @@ val nieuweWeg =
 val papendrechtOosteind =
     DrechtstedenTwinModel(
         projectPath = "/papendrechtoosteind",
-        label = LocalizedText(nl = "Digital twin Papendrecht Oosteind"),
+        label = LocalizedText(nl = "Energy Twin Papendrecht Oosteind"),
         applicationArea = DrechtstedenProjectArea.BUSINESS_PARKS,
         entryPoint = "drechtsteden/businessparks/papendrechtoosteind",
         imageUrl = "/lux/images/drechtsteden/business-parks/papendrecht_oosteind.png",
@@ -115,7 +115,7 @@ val papendrechtOosteind =
 val sliedrechtBusinesspark =
     DrechtstedenTwinModel(
         projectPath = "/sliedrechtbusinesspark",
-        label = LocalizedText(nl = "Digital twin Sliedrecht"),
+        label = LocalizedText(nl = "Energy Twin Sliedrecht"),
         applicationArea = DrechtstedenProjectArea.BUSINESS_PARKS,
         entryPoint = "drechtsteden/businessparks/sliedrecht",
         imageUrl = "/lux/images/drechtsteden/business-parks/FeaturedImageSliedrechtPagina.png",

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/municipalities/Dordrecht.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/municipalities/Dordrecht.kt
@@ -2,6 +2,7 @@ package com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsted
 
 import androidx.compose.runtime.Composable
 import com.zenmo.web.zenmo.domains.lux.subdomains.components.ZenmoModellerProfileCard
+import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.BusinessParkModelPageText
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.DrechtstedenTwinModelPage
 import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
 
@@ -10,6 +11,7 @@ import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
 fun Dordrecht() {
     DrechtstedenTwinModelPage(
         twin = dordrecht,
+        introContent = { BusinessParkModelPageText() },
         footerContent = {
             ZenmoModellerProfileCard(ZenmoTeam.ATE)
         }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/municipalities/GemeenteAlblasserdamPage.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/municipalities/GemeenteAlblasserdamPage.kt
@@ -1,36 +1,18 @@
 package com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.pages.municipalities
 
 import androidx.compose.runtime.Composable
-import com.zenmo.web.zenmo.components.widgets.LangText
 import com.zenmo.web.zenmo.domains.lux.subdomains.components.ZenmoModellerProfileCard
+import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.BusinessParkModelPageText
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.DrechtstedenTwinModelPage
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.ModelInDevelopmentInfoWidget
 import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
-import org.jetbrains.compose.web.dom.P
 
 @Composable
 fun GemeenteAlblasserdamPage() {
     ModelInDevelopmentInfoWidget()
     DrechtstedenTwinModelPage(
         twin = alblasserdam,
-        introContent = {
-            P {
-                LangText(
-                    en = """
-                Below you can find the digital twin for the sustainability of the business parks in the Municipality 
-                of Alblasserdam. The companies in this municipality are exploring whether they can share energy and 
-                invest in sustainable technologies together. The digital twin will assist in designing these sustainable 
-                energy systems and making the right decisions.
-            """.trimIndent(),
-                    nl = """
-                Bekijk hieronder  de digital twin voor de verduurzaming van de bedrijventerreinen in Gemeente 
-                Alblasserdam. De bedrijven in deze gemeente zijn aan het onderzoeken of ze samen energie kunnen delen 
-                en investeren in duurzame technieken. De digital twin zal helpen bij het ontwerpen van deze duurzame 
-                energiesystemen en het maken van de juiste beslissingen.
-            """.trimIndent(),
-                )
-            }
-        },
+        introContent = { BusinessParkModelPageText() },
         footerContent = {
             ZenmoModellerProfileCard(ZenmoTeam.ATE)
         }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/municipalities/GemeenteSliedrechtPage.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/municipalities/GemeenteSliedrechtPage.kt
@@ -1,12 +1,11 @@
 package com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.pages.municipalities
 
 import androidx.compose.runtime.Composable
-import com.zenmo.web.zenmo.components.widgets.LangText
 import com.zenmo.web.zenmo.domains.lux.subdomains.components.ZenmoModellerProfileCard
+import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.BusinessParkModelPageText
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.DrechtstedenTwinModelPage
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.ModelInDevelopmentInfoWidget
 import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
-import org.jetbrains.compose.web.dom.P
 
 
 @Composable
@@ -14,24 +13,7 @@ fun GemeenteSliedrechtPage() {
     ModelInDevelopmentInfoWidget()
     DrechtstedenTwinModelPage(
         twin = sliedrechtMunicipality,
-        introContent = {
-            P {
-                LangText(
-                    en = """
-                Below you can find the digital twin for the sustainability of the business parks in the Municipality 
-                of Alblasserdam. The companies in this municipality are exploring whether they can share energy and 
-                invest in sustainable technologies together. The digital twin will assist in designing these sustainable 
-                energy systems and making the right decisions.
-            """.trimIndent(),
-                    nl = """
-                Bekijk hieronder  de digital twin voor de verduurzaming van de bedrijventerreinen in Gemeente 
-                Alblasserdam. De bedrijven in deze gemeente zijn aan het onderzoeken of ze samen energie kunnen delen 
-                en investeren in duurzame technieken. De digital twin zal helpen bij het ontwerpen van deze duurzame 
-                energiesystemen en het maken van de juiste beslissingen.
-            """.trimIndent(),
-                )
-            }
-        },
+        introContent = { BusinessParkModelPageText() },
         footerContent = {
             ZenmoModellerProfileCard(ZenmoTeam.ATE)
         }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/municipalities/HardinxveldPage.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/municipalities/HardinxveldPage.kt
@@ -1,36 +1,18 @@
 package com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.pages.municipalities
 
 import androidx.compose.runtime.Composable
-import com.zenmo.web.zenmo.components.widgets.LangText
 import com.zenmo.web.zenmo.domains.lux.subdomains.components.ZenmoModellerProfileCard
+import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.BusinessParkModelPageText
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.DrechtstedenTwinModelPage
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.ModelInDevelopmentInfoWidget
 import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
-import org.jetbrains.compose.web.dom.P
 
 @Composable
 fun HardinxveldPage() {
     ModelInDevelopmentInfoWidget()
     DrechtstedenTwinModelPage(
         twin = hardinxveld,
-        introContent = {
-            P {
-                LangText(
-                    en = """
-                Below you can find the digital twin for the sustainability of the business parks in the municipality 
-                of Hardinxveld-Giessendam. The companies in this municipality are exploring whether they can share 
-                energy and invest in sustainable technologies together. The digital twin will help design these 
-                sustainable energy systems and make the right decisions.
-            """.trimIndent(),
-                    nl = """
-                Bekijk hieronder  de digital twin voor de verduurzaming van de bedrijventerreinen in Gemeente 
-                Hardinxveld-Giessendam. De bedrijven in deze gemeente zijn aan het onderzoeken of ze samen energie 
-                kunnen delen en investeren in duurzame technieken. De digital twin zal helpen bij het ontwerpen van 
-                deze duurzame energiesystemen en het maken van de juiste beslissingen.
-            """.trimIndent(),
-                )
-            }
-        },
+        introContent = { BusinessParkModelPageText() },
         footerContent = {
             ZenmoModellerProfileCard(ZenmoTeam.ATE)
         }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/municipalities/HendrikIdoAmbacht.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/municipalities/HendrikIdoAmbacht.kt
@@ -2,6 +2,7 @@ package com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsted
 
 import androidx.compose.runtime.Composable
 import com.zenmo.web.zenmo.domains.lux.subdomains.components.ZenmoModellerProfileCard
+import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.BusinessParkModelPageText
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.DrechtstedenTwinModelPage
 import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
 
@@ -10,6 +11,7 @@ import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
 fun HendrikIdoAmbacht() {
     DrechtstedenTwinModelPage(
         twin = hendrikIdoAmbacht,
+        introContent = { BusinessParkModelPageText() },
         footerContent = {
             ZenmoModellerProfileCard(ZenmoTeam.ATE)
         }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/municipalities/Papendrecht.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/municipalities/Papendrecht.kt
@@ -2,6 +2,7 @@ package com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsted
 
 import androidx.compose.runtime.Composable
 import com.zenmo.web.zenmo.domains.lux.subdomains.components.ZenmoModellerProfileCard
+import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.BusinessParkModelPageText
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.DrechtstedenTwinModelPage
 import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
 
@@ -10,6 +11,7 @@ import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
 fun Papendrecht() {
     DrechtstedenTwinModelPage(
         twin = papendrecht,
+        introContent = { BusinessParkModelPageText() },
         footerContent = {
             ZenmoModellerProfileCard(ZenmoTeam.ATE)
         }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/municipalities/Zwijndrecht.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/municipalities/Zwijndrecht.kt
@@ -2,6 +2,7 @@ package com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsted
 
 import androidx.compose.runtime.Composable
 import com.zenmo.web.zenmo.domains.lux.subdomains.components.ZenmoModellerProfileCard
+import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.BusinessParkModelPageText
 import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.components.DrechtstedenTwinModelPage
 import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
 
@@ -10,6 +11,7 @@ import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
 fun Zwijndrecht() {
     DrechtstedenTwinModelPage(
         twin = zwijndrecht,
+        introContent = { BusinessParkModelPageText() },
         footerContent = {
             ZenmoModellerProfileCard(ZenmoTeam.ATE)
         }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/municipalities/drechtstedenMunicipalityModels.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/municipalities/drechtstedenMunicipalityModels.kt
@@ -8,7 +8,7 @@ import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtstede
 val alblasserdam =
     DrechtstedenTwinModel(
         projectPath = "/alblasserdam",
-        label = LocalizedText(nl = "Digital twin Gemeente Alblasserdam"),
+        label = LocalizedText(nl = "Energy Twin Gemeente Alblasserdam"),
         applicationArea = DrechtstedenProjectArea.BUSINESS_PARKS,
         entryPoint = "drechtsteden/municipalities/alblasserdam",
         imageUrl = "/lux/images/drechtsteden/municipalities/Gemeente_Alblasserdam_foto.png",
@@ -18,7 +18,7 @@ val alblasserdam =
 val hardinxveld =
     DrechtstedenTwinModel(
         projectPath = "/hardinxveld",
-        label = LocalizedText(nl = "Digital twin Gemeente Hardinxveld-Giessendam"),
+        label = LocalizedText(nl = "Energy Twin Gemeente Hardinxveld-Giessendam"),
         applicationArea = DrechtstedenProjectArea.BUSINESS_PARKS,
         entryPoint = "drechtsteden/municipalities/hardinxveld",
         imageUrl = "/lux/images/drechtsteden/municipalities/Gemeente_Hardinxveld-Giessendam_foto.png",
@@ -27,7 +27,7 @@ val hardinxveld =
 val sliedrechtMunicipality =
     DrechtstedenTwinModel(
         projectPath = "/sliedrechtmunicipality",
-        label = LocalizedText(nl = "Digital twin Gemeente Sliedrecht"),
+        label = LocalizedText(nl = "Energy Twin Gemeente Sliedrecht"),
         applicationArea = DrechtstedenProjectArea.BUSINESS_PARKS,
         entryPoint = "drechtsteden/municipalities/sliedrecht",
         imageUrl = "/lux/images/drechtsteden/municipalities/Gemeente_Sliedrecht_foto.png",
@@ -36,7 +36,7 @@ val sliedrechtMunicipality =
 val dordrecht =
     DrechtstedenTwinModel(
         projectPath = "/dordrecht",
-        label = LocalizedText(nl = "Digital twin Dordrecht"),
+        label = LocalizedText(nl = "Energy Twin Dordrecht"),
         applicationArea = DrechtstedenProjectArea.BUSINESS_PARKS,
         entryPoint = "drechtsteden/municipalities/dordrecht",
         imageUrl = "/lux/images/drechtsteden/municipalities/dordrecht.png",
@@ -45,7 +45,7 @@ val dordrecht =
 val papendrecht =
     DrechtstedenTwinModel(
         projectPath = "/papendrecht",
-        label = LocalizedText(nl = "Digital twin Papendrecht"),
+        label = LocalizedText(nl = "Energy Twin Papendrecht"),
         applicationArea = DrechtstedenProjectArea.BUSINESS_PARKS,
         entryPoint = "drechtsteden/municipalities/papendrecht",
         imageUrl = "/lux/images/drechtsteden/municipalities/papendrecht.png",
@@ -54,7 +54,7 @@ val papendrecht =
 val zwijndrecht =
     DrechtstedenTwinModel(
         projectPath = "/zwijndrecht",
-        label = LocalizedText(nl = "Digital twin Zwijndrecht"),
+        label = LocalizedText(nl = "Energy Twin Zwijndrecht"),
         applicationArea = DrechtstedenProjectArea.BUSINESS_PARKS,
         entryPoint = "drechtsteden/municipalities/zwijndrecht",
         imageUrl = "/lux/images/drechtsteden/municipalities/zwijndrecht.png",
@@ -63,7 +63,7 @@ val zwijndrecht =
 val hendrikIdoAmbacht =
     DrechtstedenTwinModel(
         projectPath = "/hendrikidoambacht",
-        label = LocalizedText(nl = "Digital twin Hendrik-Ido-Ambacht"),
+        label = LocalizedText(nl = "Energy Twin Hendrik-Ido-Ambacht"),
         applicationArea = DrechtstedenProjectArea.BUSINESS_PARKS,
         entryPoint = "drechtsteden/municipalities/hendrikidoambacht",
         imageUrl = "/lux/images/drechtsteden/municipalities/hendrik_ido_ambacht.png",

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/resneighborhoods/drechtstedenResNeighborhoodsModels.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/pages/resneighborhoods/drechtstedenResNeighborhoodsModels.kt
@@ -7,7 +7,7 @@ import com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtstede
 val overTSpoor =
     DrechtstedenTwinModel(
         projectPath = "/overtspoor",
-        label = LocalizedText(nl = "Digital twin Over 't Spoor"),
+        label = LocalizedText(nl = "Energy Twin Over 't Spoor"),
         applicationArea = DrechtstedenProjectArea.RESIDENTIAL_AREAS,
         entryPoint = "drechtsteden/resneighborhoods/overtspoor",
         imageUrl = "/lux/images/drechtsteden/resneighborhoods/over_t_spoor.png",
@@ -16,7 +16,7 @@ val overTSpoor =
 val oostdonk =
     DrechtstedenTwinModel(
         projectPath = "/oostdonk",
-        label = LocalizedText(nl = "Digital twin Oostdonk"),
+        label = LocalizedText(nl = "Energy Twin Oostdonk"),
         applicationArea = DrechtstedenProjectArea.RESIDENTIAL_AREAS,
         entryPoint = "drechtsteden/resneighborhoods/oostdonk",
         imageUrl = "/lux/images/drechtsteden/resneighborhoods/oostdonk.png",
@@ -25,7 +25,7 @@ val oostdonk =
 val kerkbuurt =
     DrechtstedenTwinModel(
         projectPath = "/kerkbuurt",
-        label = LocalizedText(nl = "Digital twin Kerkbuurt"),
+        label = LocalizedText(nl = "Energy Twin Kerkbuurt"),
         applicationArea = DrechtstedenProjectArea.RESIDENTIAL_AREAS,
         entryPoint = "drechtsteden/resneighborhoods/kerkbuurt",
         imageUrl = "/lux/images/drechtsteden/resneighborhoods/kerkbuurt.png",


### PR DESCRIPTION
- also renames all `digital twin` references in titles to `energy twin` 