### PR TITLE
add `isFeatured` flag to `TwinModelCard` for featured model selection for LUX application area pages

### DIFF
--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/components/layout/LuxEnergyLayout.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/components/layout/LuxEnergyLayout.kt
@@ -2,31 +2,18 @@ package com.zenmo.web.zenmo.domains.lux.components.layout
 
 import androidx.compose.runtime.Composable
 import com.zenmo.web.zenmo.components.layouts.PageLayout
-import com.zenmo.web.zenmo.domains.lux.sections.application_fields.FieldModels
-import com.zenmo.web.zenmo.domains.lux.sections.application_fields.LuxApplicationArea
-import com.zenmo.web.zenmo.domains.lux.sections.application_fields.components.ApplicationAreaContactPerson
 import com.zenmo.web.zenmo.domains.lux.sections.nav_header.LuxHeader
-import kotlinx.browser.window
 
 
 @Composable
 fun LuxEnergyLayout(
     content: @Composable () -> Unit
 ) {
-    val currentApplicationArea = LuxApplicationArea.entries
-        .firstOrNull { it.path == window.location.pathname }
-
     PageLayout(
         header = { LuxHeader() },
         footer = {},
         title = ""
     ) {
         content()
-        if (currentApplicationArea != null) {
-            FieldModels(
-                applicationArea = currentApplicationArea
-            )
-            ApplicationAreaContactPerson(currentApplicationArea.contactPerson)
-        }
     }
 }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/FieldModels.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/FieldModels.kt
@@ -2,41 +2,89 @@ package com.zenmo.web.zenmo.domains.lux.sections.application_fields
 
 import androidx.compose.runtime.Composable
 import com.varabyte.kobweb.compose.foundation.layout.Arrangement
+import com.varabyte.kobweb.compose.foundation.layout.Column
+import com.varabyte.kobweb.compose.foundation.layout.Row
 import com.varabyte.kobweb.compose.ui.Alignment
 import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.graphics.Colors
 import com.varabyte.kobweb.compose.ui.modifiers.background
+import com.varabyte.kobweb.compose.ui.modifiers.color
+import com.varabyte.kobweb.compose.ui.modifiers.gap
+import com.varabyte.kobweb.compose.ui.modifiers.padding
+import com.varabyte.kobweb.silk.components.icons.mdi.MdiArrowForward
+import com.varabyte.kobweb.silk.components.navigation.Link
+import com.varabyte.kobweb.silk.components.navigation.UncoloredLinkVariant
+import com.varabyte.kobweb.silk.components.navigation.UndecoratedLinkVariant
 import com.varabyte.kobweb.silk.style.toModifier
-import com.zenmo.web.zenmo.components.widgets.SectionContainer
-import com.zenmo.web.zenmo.domains.lux.core.model.subdomain.subdomainModels
-import com.zenmo.web.zenmo.domains.lux.core.toTwinModelCardItem
-import com.zenmo.web.zenmo.domains.lux.sections.LuxSectionContainerStyleVariant
+import com.zenmo.web.zenmo.components.widgets.LangText
+import com.zenmo.web.zenmo.domains.lux.components.LuxSectionContainer
+import com.zenmo.web.zenmo.domains.lux.core.TwinModelCardItem
+import com.zenmo.web.zenmo.domains.lux.sections.nav_header.luxModelsMenuItem
 import com.zenmo.web.zenmo.domains.lux.styles.TopDividerLineStyle
+import com.zenmo.web.zenmo.domains.lux.styles.verticalLinearBackground
 import com.zenmo.web.zenmo.domains.lux.widgets.TwinModelsGrid
 import com.zenmo.web.zenmo.domains.lux.widgets.headings.HeaderText
 import com.zenmo.web.zenmo.theme.SitePalette
+import com.zenmo.web.zenmo.theme.styles.luxBorderRadius
+import org.jetbrains.compose.web.css.px
+import org.jetbrains.compose.web.dom.P
 
 
 @Composable
 fun FieldModels(
-    applicationArea: ApplicationArea
+    featuredModels: List<TwinModelCardItem>,
+    showMoreModelsLink: Boolean,
 ) {
-    SectionContainer(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
+    LuxSectionContainer(
         modifier =
             Modifier
                 .then(TopDividerLineStyle.toModifier())
                 .background(SitePalette.light.overlay),
-        variant = LuxSectionContainerStyleVariant
     ) {
-        HeaderText(
-            enText = "Models",
-            nlText = "Modellen",
-        )
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            HeaderText(
+                enText = "Example Models",
+                nlText = "Voorbeeldmodellen",
+            )
+            if (showMoreModelsLink) {
+                P {
+                    LangText(
+                        en = "Explore more real-world examples and detailed simulations.",
+                        nl = "Ontdek meer praktijkvoorbeelden en gedetailleerde simulaties."
+                    )
+                }
+                BrowseAllModelsLink()
+            }
+        }
         TwinModelsGrid(
-            models = subdomainModels
-                .map { it.toTwinModelCardItem() }
-                .filter { it.applicationArea == applicationArea },
+            models = featuredModels,
         )
+    }
+}
+
+@Composable
+private fun BrowseAllModelsLink() {
+    Link(
+        path = luxModelsMenuItem.route.path,
+        variant = UncoloredLinkVariant.then(UndecoratedLinkVariant),
+    ) {
+        Row(
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .verticalLinearBackground()
+                .padding(8.px, 16.px)
+                .gap(8.px)
+                .color(Colors.White)
+                .luxBorderRadius()
+        ) {
+            LangText(
+                en = "Browse all models",
+                nl = "Bekijk alle modellen"
+            )
+            MdiArrowForward()
+        }
     }
 }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/LuxApplicationArea.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/LuxApplicationArea.kt
@@ -9,11 +9,9 @@ import com.zenmo.web.zenmo.domains.lux.sections.application_fields.lux_company.L
 import com.zenmo.web.zenmo.domains.lux.sections.application_fields.lux_enegy_hub.LuxEnergyHub
 import com.zenmo.web.zenmo.domains.lux.sections.application_fields.lux_region.LuxRegion
 import com.zenmo.web.zenmo.domains.lux.sections.application_fields.lux_res_area.LuxNeighbourhood
-import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
 
 enum class LuxApplicationArea(
     val shortDescription: LocalizedText,
-    val contactPerson: ZenmoTeam,
     override val label: LocalizedText,
     override val areaTitle: LocalizedText = label,
     override val path: String = label.en.asNavLinkPath("application-areas"),
@@ -22,7 +20,6 @@ enum class LuxApplicationArea(
 ) : Route, SimpleMenuItem, ApplicationArea {
     LUX_BUSINESS(
         label = LocalizedText("LUX Bedrijf", "LUX Business"),
-        contactPerson = ZenmoTeam.PETER_HOGEVEEN,
         shortDescription = LocalizedText(
             "Inzicht in batterijwaarde en energieflexibiliteit",
             "Insight into battery value and energy flexibility",
@@ -31,7 +28,6 @@ enum class LuxApplicationArea(
     ),
     LUX_ENERGY_HUB(
         label = LocalizedText("LUX Energie Hub", "LUX Energy Hub"),
-        contactPerson = ZenmoTeam.AUKE,
         shortDescription = LocalizedText(
             "Lokale energie- en netcongestie-analyse",
             "Local energy and grid congestion analysis",
@@ -40,7 +36,6 @@ enum class LuxApplicationArea(
     ),
     LUX_NEIGHBOURHOOD(
         label = LocalizedText("LUX Woonwijk", "LUX Neighbourhood"),
-        contactPerson = ZenmoTeam.PETER_HOGEVEEN,
         shortDescription = LocalizedText(
             "Energie- en netanalyse voor woonwijken",
             "Energy and grid analysis for residential neighbourhoods",
@@ -49,7 +44,6 @@ enum class LuxApplicationArea(
     ),
     LUX_REGION(
         label = LocalizedText("LUX Regio", "LUX Region"),
-        contactPerson = ZenmoTeam.NAUD_LOOMANS,
         shortDescription = LocalizedText(
             "Regionale energie- en congestiescenario’s",
             "Regional energy and congestion scenarios",

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/lux_company/LuxCompany.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/lux_company/LuxCompany.kt
@@ -4,7 +4,13 @@ import androidx.compose.runtime.Composable
 import com.varabyte.kobweb.compose.foundation.layout.Column
 import com.varabyte.kobweb.compose.ui.Modifier
 import com.varabyte.kobweb.compose.ui.modifiers.fillMaxWidth
+import com.zenmo.web.zenmo.domains.lux.core.model.subdomain.PrivateSubdomainModel
+import com.zenmo.web.zenmo.domains.lux.core.model.subdomain.cognizant
+import com.zenmo.web.zenmo.domains.lux.core.toTwinModelCardItem
+import com.zenmo.web.zenmo.domains.lux.sections.application_fields.FieldModels
+import com.zenmo.web.zenmo.domains.lux.sections.application_fields.components.ApplicationAreaContactPerson
 import com.zenmo.web.zenmo.domains.lux.sections.application_fields.lux_company.components.*
+import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
 
 
 @Composable
@@ -19,5 +25,13 @@ fun LuxCompany(
         InteractiveDashboardSection()
         PersonalAdvice()
         UniqueFeature()
+        FieldModels(
+            featuredModels = listOf(
+                cognizant.toTwinModelCardItem(),
+                PrivateSubdomainModel.PREZERO.toTwinModelCardItem(),
+            ),
+            showMoreModelsLink = false,
+        )
+        ApplicationAreaContactPerson(ZenmoTeam.PETER_HOGEVEEN)
     }
 }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/lux_enegy_hub/LuxEnergyHub.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/lux_enegy_hub/LuxEnergyHub.kt
@@ -3,9 +3,14 @@ package com.zenmo.web.zenmo.domains.lux.sections.application_fields.lux_enegy_hu
 import androidx.compose.runtime.Composable
 import com.varabyte.kobweb.compose.foundation.layout.Column
 import com.varabyte.kobweb.framework.annotations.DelicateApi
+import com.zenmo.web.zenmo.domains.lux.core.model.subdomain.PrivateSubdomainModel
+import com.zenmo.web.zenmo.domains.lux.core.toTwinModelCardItem
+import com.zenmo.web.zenmo.domains.lux.sections.application_fields.FieldModels
+import com.zenmo.web.zenmo.domains.lux.sections.application_fields.components.ApplicationAreaContactPerson
 import com.zenmo.web.zenmo.domains.lux.sections.application_fields.lux_enegy_hub.components.DidYouKNowSection
 import com.zenmo.web.zenmo.domains.lux.sections.application_fields.lux_enegy_hub.components.LuxEnergyHubHero
 import com.zenmo.web.zenmo.domains.lux.sections.application_fields.lux_enegy_hub.components.energy_hub_process.EnergyHubProcessSection
+import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
 
 
 @OptIn(DelicateApi::class)
@@ -15,5 +20,14 @@ fun LuxEnergyHub() {
         LuxEnergyHubHero()
         DidYouKNowSection()
         EnergyHubProcessSection()
+        FieldModels(
+            featuredModels = listOf(
+                PrivateSubdomainModel.HESSENPOORT.toTwinModelCardItem(),
+                PrivateSubdomainModel.GENUIS.toTwinModelCardItem(),
+                PrivateSubdomainModel.KAS_ALS_ENERGIEBRON.toTwinModelCardItem(),
+            ),
+            showMoreModelsLink = true,
+        )
+        ApplicationAreaContactPerson(ZenmoTeam.AUKE)
     }
 }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/lux_region/LuxRegion.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/lux_region/LuxRegion.kt
@@ -2,7 +2,14 @@ package com.zenmo.web.zenmo.domains.lux.sections.application_fields.lux_region
 
 import androidx.compose.runtime.Composable
 import com.varabyte.kobweb.compose.foundation.layout.Column
+import com.zenmo.web.zenmo.domains.lux.core.model.subdomain.PrivateSubdomainModel
+import com.zenmo.web.zenmo.domains.lux.core.model.subdomain.empowered
+import com.zenmo.web.zenmo.domains.lux.core.model.subdomain.hilversum
+import com.zenmo.web.zenmo.domains.lux.core.toTwinModelCardItem
+import com.zenmo.web.zenmo.domains.lux.sections.application_fields.FieldModels
+import com.zenmo.web.zenmo.domains.lux.sections.application_fields.components.ApplicationAreaContactPerson
 import com.zenmo.web.zenmo.domains.lux.sections.application_fields.lux_region.components.*
+import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
 
 
 @Composable
@@ -14,5 +21,14 @@ fun LuxRegion() {
         WhatIfScenarios()
         MultiScaleAnalysis()
         ConsistentInterface()
+        FieldModels(
+            featuredModels = listOf(
+                PrivateSubdomainModel.DRECHTSTEDEN.toTwinModelCardItem(),
+                empowered.toTwinModelCardItem(),
+                hilversum.toTwinModelCardItem(),
+            ),
+            showMoreModelsLink = true,
+        )
+        ApplicationAreaContactPerson(ZenmoTeam.NAUD_LOOMANS)
     }
 }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/lux_res_area/LuxNeighbourhood.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/lux_res_area/LuxNeighbourhood.kt
@@ -3,11 +3,18 @@ package com.zenmo.web.zenmo.domains.lux.sections.application_fields.lux_res_area
 import androidx.compose.runtime.Composable
 import com.varabyte.kobweb.compose.foundation.layout.Column
 import com.varabyte.kobweb.framework.annotations.DelicateApi
+import com.zenmo.web.zenmo.domains.lux.core.model.subdomain.bunderbuurten
+import com.zenmo.web.zenmo.domains.lux.core.model.subdomain.kronenberg
+import com.zenmo.web.zenmo.domains.lux.core.model.subdomain.loenen
+import com.zenmo.web.zenmo.domains.lux.core.toTwinModelCardItem
+import com.zenmo.web.zenmo.domains.lux.sections.application_fields.FieldModels
+import com.zenmo.web.zenmo.domains.lux.sections.application_fields.components.ApplicationAreaContactPerson
 import com.zenmo.web.zenmo.domains.lux.sections.application_fields.lux_res_area.components.LuxNeighbourhoodFactAndDemo
 import com.zenmo.web.zenmo.domains.lux.sections.application_fields.lux_res_area.components.QuestionsGrid
 import com.zenmo.web.zenmo.domains.lux.sections.application_fields.lux_res_area.components.ResAreaPersonalAdvice
 import com.zenmo.web.zenmo.domains.lux.sections.application_fields.lux_res_area.components.ResHero
 import com.zenmo.web.zenmo.domains.lux.sections.application_fields.lux_res_area.components.get_lux_neighbourhood.GetLuxNeighbourhoodSection
+import com.zenmo.web.zenmo.domains.zenmo.sections.team.ZenmoTeam
 
 
 @OptIn(DelicateApi::class)
@@ -19,5 +26,14 @@ fun LuxNeighbourhood() {
         LuxNeighbourhoodFactAndDemo()
         GetLuxNeighbourhoodSection()
         ResAreaPersonalAdvice()
+        FieldModels(
+            featuredModels = listOf(
+                bunderbuurten.toTwinModelCardItem(),
+                loenen.toTwinModelCardItem(),
+                kronenberg.toTwinModelCardItem(),
+            ),
+            showMoreModelsLink = true,
+        )
+        ApplicationAreaContactPerson(ZenmoTeam.PETER_HOGEVEEN)
     }
 }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/luxmodels/LuxModels.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/luxmodels/LuxModels.kt
@@ -1,34 +1,29 @@
 package com.zenmo.web.zenmo.domains.lux.sections.luxmodels
 
 import androidx.compose.runtime.*
-import com.varabyte.kobweb.compose.css.TextTransform
 import com.varabyte.kobweb.compose.foundation.layout.Arrangement
 import com.varabyte.kobweb.compose.foundation.layout.Column
-import com.varabyte.kobweb.compose.foundation.layout.Row
 import com.varabyte.kobweb.compose.ui.Alignment
 import com.varabyte.kobweb.compose.ui.Modifier
-import com.varabyte.kobweb.compose.ui.modifiers.*
+import com.varabyte.kobweb.compose.ui.modifiers.background
+import com.varabyte.kobweb.compose.ui.modifiers.gap
+import com.varabyte.kobweb.compose.ui.modifiers.margin
 import com.varabyte.kobweb.compose.ui.toAttrs
-import com.varabyte.kobweb.silk.components.icons.mdi.MdiLock
 import com.varabyte.kobweb.silk.style.toModifier
 import com.zenmo.web.zenmo.components.widgets.LangText
-import com.zenmo.web.zenmo.components.widgets.SectionContainer
+import com.zenmo.web.zenmo.domains.lux.components.LuxSectionContainer
 import com.zenmo.web.zenmo.domains.lux.core.model.subdomain.subdomainModels
 import com.zenmo.web.zenmo.domains.lux.core.toTwinModelCardItem
-import com.zenmo.web.zenmo.domains.lux.sections.DeEmphasizedTextStyle
-import com.zenmo.web.zenmo.domains.lux.sections.LuxSectionContainerStyleVariant
-import com.zenmo.web.zenmo.domains.lux.sections.luxmodels.components.EmptyResults
-import com.zenmo.web.zenmo.domains.lux.sections.luxmodels.components.SearchBar
-import com.zenmo.web.zenmo.domains.lux.sections.luxmodels.components.filterAndSearchModels
-import com.zenmo.web.zenmo.domains.lux.widgets.RadioRow
+import com.zenmo.web.zenmo.domains.lux.sections.ResponsiveFlexStyle
+import com.zenmo.web.zenmo.domains.lux.sections.application_fields.LuxApplicationArea
+import com.zenmo.web.zenmo.domains.lux.sections.luxmodels.components.*
 import com.zenmo.web.zenmo.domains.lux.widgets.TwinModelsGrid
 import com.zenmo.web.zenmo.domains.lux.widgets.headings.HeaderText
 import com.zenmo.web.zenmo.theme.SitePalette
-import org.jetbrains.compose.web.css.Position
 import org.jetbrains.compose.web.css.cssRem
 import org.jetbrains.compose.web.css.px
+import org.jetbrains.compose.web.dom.Div
 import org.jetbrains.compose.web.dom.P
-import org.jetbrains.compose.web.dom.Span
 
 
 enum class FilterType {
@@ -40,17 +35,13 @@ enum class FilterType {
 
 @Composable
 fun LuxModels() {
-    SectionContainer(
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
+    LuxSectionContainer(
         modifier =
             Modifier
                 .background(SitePalette.light.overlay)
-                .position(Position.Relative)
-                .gap(5.cssRem),
-        variant = LuxSectionContainerStyleVariant
     ) {
         var query by remember { mutableStateOf("") }
+        var selectedAreaOptions by remember { mutableStateOf(emptySet<LuxApplicationArea>()) }
 
         val allModels =
             (subdomainModels + com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.drechtsteden.drechtstedenModels).map { it.toTwinModelCardItem() }
@@ -82,49 +73,41 @@ fun LuxModels() {
                     luxModels = filterAndSearchModels(
                         models = allModels,
                         query = query,
-                        filterType = filterType
+                        filterType = filterType,
+                        areas = selectedAreaOptions
                     )
                 }
             )
 
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
+            Div(
+                ResponsiveFlexStyle.toModifier()
+                    .gap(0.5.cssRem)
+                    .toAttrs()
             ) {
-                Span(
-                    attrs = DeEmphasizedTextStyle.toModifier()
-                        .textTransform(TextTransform.Uppercase)
-                        .padding(bottom = 8.px)
-                        .toAttrs()
-                ) {
-                    LangText(
-                        en = "Access",
-                        nl = "Toegang"
-                    )
-                }
-                RadioRow(
-                    value = filterType,
-                    options = FilterType.entries.associateWith { it.name },
-                    onChange = { type ->
+                ModelAccessFilter(
+                    filterType = filterType,
+                    onFilterChange = { type ->
                         filterType = type
                         luxModels = filterAndSearchModels(
                             models = allModels,
                             query = query,
-                            filterType = filterType
+                            filterType = filterType,
+                            areas = selectedAreaOptions
                         )
                     }
-                ) { option, _ ->
-                    when (option) {
-                        FilterType.ALL -> LangText(en = "All", nl = "Alle")
-                        FilterType.PUBLIC -> LangText(en = "Public", nl = "Openbaar")
-                        FilterType.PRIVATE -> Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(4.px)
-                        ) {
-                            MdiLock(Modifier.fontSize(16.px))
-                            LangText(en = "Private", nl = "Privé")
-                        }
+                )
+                ModelAreaFilter(
+                    selectedOptions = selectedAreaOptions,
+                    onSelectionChange = {
+                        selectedAreaOptions = it
+                        luxModels = filterAndSearchModels(
+                            models = allModels,
+                            query = query,
+                            filterType = filterType,
+                            areas = selectedAreaOptions
+                        )
                     }
-                }
+                )
             }
         }
 

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/luxmodels/components/ModelAccessFilter.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/luxmodels/components/ModelAccessFilter.kt
@@ -1,0 +1,42 @@
+package com.zenmo.web.zenmo.domains.lux.sections.luxmodels.components
+
+import androidx.compose.runtime.Composable
+import com.varabyte.kobweb.compose.foundation.layout.Arrangement
+import com.varabyte.kobweb.compose.foundation.layout.Row
+import com.varabyte.kobweb.compose.ui.Alignment
+import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.modifiers.fontSize
+import com.varabyte.kobweb.silk.components.icons.mdi.MdiLock
+import com.zenmo.web.zenmo.components.widgets.LangText
+import com.zenmo.web.zenmo.core.services.localization.LocalizedText
+import com.zenmo.web.zenmo.domains.lux.sections.luxmodels.FilterType
+import com.zenmo.web.zenmo.domains.lux.widgets.RadioRow
+import org.jetbrains.compose.web.css.px
+
+@Composable
+fun ModelAccessFilter(
+    filterType: FilterType,
+    onFilterChange: (FilterType) -> Unit
+) {
+    ModelFilter(
+        filterLabel = LocalizedText(en = "Access", nl = "Toegang")
+    ) {
+        RadioRow(
+            value = filterType,
+            options = FilterType.entries.associateWith { it.name },
+            onChange = onFilterChange
+        ) { option, _ ->
+            when (option) {
+                FilterType.ALL -> LangText(en = "All", nl = "Alle")
+                FilterType.PUBLIC -> LangText(en = "Public", nl = "Openbaar")
+                FilterType.PRIVATE -> Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(4.px)
+                ) {
+                    MdiLock(Modifier.fontSize(16.px))
+                    LangText(en = "Private", nl = "Privé")
+                }
+            }
+        }
+    }
+}

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/luxmodels/components/ModelAreaFilter.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/luxmodels/components/ModelAreaFilter.kt
@@ -1,0 +1,30 @@
+package com.zenmo.web.zenmo.domains.lux.sections.luxmodels.components
+
+import androidx.compose.runtime.Composable
+import com.zenmo.web.zenmo.core.services.localization.Language
+import com.zenmo.web.zenmo.core.services.localization.LocalLanguage
+import com.zenmo.web.zenmo.core.services.localization.LocalizedText
+import com.zenmo.web.zenmo.domains.lux.sections.application_fields.LuxApplicationArea
+import com.zenmo.web.zenmo.domains.lux.widgets.MultiSelectRow
+
+@Composable
+fun ModelAreaFilter(
+    selectedOptions: Set<LuxApplicationArea>,
+    onSelectionChange: (Set<LuxApplicationArea>) -> Unit,
+) {
+    val currentLanguage = LocalLanguage.current
+    ModelFilter(
+        filterLabel = LocalizedText(en = "Application Area", nl = "Toepassingsgebied")
+    ) {
+        MultiSelectRow(
+            selectedValues = selectedOptions,
+            options = LuxApplicationArea.entries.associateWith {
+                when (currentLanguage) {
+                    Language.Dutch -> it.label.nl
+                    Language.English -> it.label.en
+                }
+            },
+            onChange = onSelectionChange
+        )
+    }
+}

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/luxmodels/components/ModelFilter.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/luxmodels/components/ModelFilter.kt
@@ -1,0 +1,46 @@
+package com.zenmo.web.zenmo.domains.lux.sections.luxmodels.components
+
+import androidx.compose.runtime.Composable
+import com.varabyte.kobweb.compose.css.TextTransform
+import com.varabyte.kobweb.compose.foundation.layout.Column
+import com.varabyte.kobweb.compose.ui.Alignment
+import com.varabyte.kobweb.compose.ui.modifiers.gap
+import com.varabyte.kobweb.compose.ui.modifiers.padding
+import com.varabyte.kobweb.compose.ui.modifiers.textTransform
+import com.varabyte.kobweb.compose.ui.toAttrs
+import com.varabyte.kobweb.silk.style.toModifier
+import com.zenmo.web.zenmo.components.widgets.LangText
+import com.zenmo.web.zenmo.core.services.localization.LocalizedText
+import com.zenmo.web.zenmo.domains.lux.sections.DeEmphasizedTextStyle
+import com.zenmo.web.zenmo.domains.lux.sections.ResponsiveFlexStyle
+import org.jetbrains.compose.web.css.cssRem
+import org.jetbrains.compose.web.css.px
+import org.jetbrains.compose.web.dom.Div
+import org.jetbrains.compose.web.dom.Span
+
+@Composable
+fun ModelFilter(
+    filterLabel: LocalizedText,
+    content: @Composable () -> Unit,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Span(
+            attrs = DeEmphasizedTextStyle.toModifier()
+                .textTransform(TextTransform.Uppercase)
+                .padding(bottom = 8.px)
+                .toAttrs()
+        ) {
+            LangText(
+                en = filterLabel.en,
+                nl = filterLabel.nl
+            )
+        }
+        Div(
+            ResponsiveFlexStyle.toModifier()
+                .gap(0.5.cssRem)
+                .toAttrs()
+        ) { content() }
+    }
+}

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/luxmodels/components/filterAndSearchModels.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/luxmodels/components/filterAndSearchModels.kt
@@ -1,20 +1,22 @@
 package com.zenmo.web.zenmo.domains.lux.sections.luxmodels.components
 
 import com.zenmo.web.zenmo.domains.lux.core.TwinModelCardItem
+import com.zenmo.web.zenmo.domains.lux.sections.application_fields.LuxApplicationArea
 import com.zenmo.web.zenmo.domains.lux.sections.luxmodels.FilterType
 
 
 /**
- * Filters and searches a list of models based on visibility and title.
+ * Filters and searches a list of models based on visibility, matching title, and application area.
  *
- * Applies the selected [filterType] and
+ * Applies the selected [filterType], filters by [areas] if specified, and
  * optionally narrows the result by matching the [query] against
  * each model’s title (case-insensitive).
  */
 fun filterAndSearchModels(
     models: List<TwinModelCardItem>,
     query: String,
-    filterType: FilterType
+    filterType: FilterType,
+    areas: Set<LuxApplicationArea>
 ): List<TwinModelCardItem> {
     val queryString = query.trim().lowercase()
 
@@ -33,6 +35,10 @@ fun filterAndSearchModels(
             model.searchTokens.any { sTokens ->
                 sTokens.lowercase().contains(queryString)
             }
+        }
+        .filter { model ->
+            if (areas.isEmpty()) return@filter true
+            model.applicationArea in areas
         }
         .toList()
 }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/nav_header/luxNavMenu.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/nav_header/luxNavMenu.kt
@@ -7,30 +7,36 @@ import com.zenmo.web.zenmo.domains.lux.sections.about_us.AboutUs
 import com.zenmo.web.zenmo.domains.lux.sections.application_fields.LuxApplicationArea
 import com.zenmo.web.zenmo.domains.lux.sections.luxmodels.LuxModels
 
-val luxNavMenu = listOf(
-    MenuItem.WithSubs(
-        title = LocalizedText(en = "Application Areas", nl = "Toepassingsgebieden"),
-        subItems = LuxApplicationArea.entries.map { field ->
-            MenuItem.Simple(
-                route = RoutedMenuItem(
-                    path = field.path,
-                    label = field.label,
-                    pageComponent = field.pageComponent,
-                ),
-                descriptionParagraph = field.shortDescription
-            )
-        }
-    ),
-    MenuItem.Simple(
-        route = RoutedMenuItem(
-            label = LocalizedText(en = "Models", nl = "Modellen"),
-            pageComponent = { LuxModels() }
+private val applicationAreasMenuItem = MenuItem.WithSubs(
+    title = LocalizedText(en = "Application Areas", nl = "Toepassingsgebieden"),
+    subItems = LuxApplicationArea.entries.map { field ->
+        MenuItem.Simple(
+            route = RoutedMenuItem(
+                path = field.path,
+                label = field.label,
+                pageComponent = field.pageComponent,
+            ),
+            descriptionParagraph = field.shortDescription
         )
-    ),
-    MenuItem.Simple(
-        route = RoutedMenuItem(
-            label = LocalizedText(en = "About Us", nl = "Over Ons"),
-            pageComponent = { AboutUs() }
-        )
+    }
+)
+
+private val aboutUsMenuItem = MenuItem.Simple(
+    route = RoutedMenuItem(
+        label = LocalizedText(en = "About Us", nl = "Over Ons"),
+        pageComponent = { AboutUs() }
     )
+)
+
+val luxModelsMenuItem = MenuItem.Simple(
+    route = RoutedMenuItem(
+        label = LocalizedText(en = "Models", nl = "Modellen"),
+        pageComponent = { LuxModels() }
+    )
+)
+
+val luxNavMenu = listOf(
+    applicationAreasMenuItem,
+    luxModelsMenuItem,
+    aboutUsMenuItem
 )

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/widgets/MultiSelectRow.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/widgets/MultiSelectRow.kt
@@ -1,0 +1,42 @@
+package com.zenmo.web.zenmo.domains.lux.widgets
+
+import androidx.compose.runtime.Composable
+import com.varabyte.kobweb.compose.foundation.layout.Arrangement
+import com.varabyte.kobweb.compose.foundation.layout.Row
+import com.varabyte.kobweb.compose.ui.Alignment
+import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.modifiers.gap
+import org.jetbrains.compose.web.css.cssRem
+import org.jetbrains.compose.web.dom.Text
+
+@Composable
+fun <T> MultiSelectRow(
+    selectedValues: Set<T>,
+    options: Map<T, String>,
+    onChange: (Set<T>) -> Unit,
+    modifier: Modifier = Modifier.Companion,
+) {
+    Row(
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = modifier.gap(0.5.cssRem)
+    ) {
+        options.forEach { (optionValue, displayName) ->
+            val isSelected = optionValue in selectedValues
+            RadioItem(
+                onClick = {
+                    val selection = selectedValues.toMutableSet()
+                    if (isSelected) {
+                        selection.remove(optionValue)
+                    } else {
+                        selection.add(optionValue)
+                    }
+                    onChange(selection)
+                },
+                isSelected = isSelected,
+            ) {
+                Text(displayName)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Part of #445
The models page needs a filter by application area, then jump to models page with filter enabled feels more complete. 

This will be done in a different PR. 
  
 