### PR TITLE
Remove meta description

### DIFF
--- a/site/build.gradle.kts
+++ b/site/build.gradle.kts
@@ -24,7 +24,6 @@ val jsSrc = "$BACKEND_URL/main.export.mjs"
 kobweb {
     app {
         index {
-            description.set("Powered by Kobweb")
             head.add {
                 link(rel = "stylesheet", href = "/fonts/faces.css")
             }


### PR DESCRIPTION
I wanted to set the meta description for every page but I noticed that google doesn't even show it and some serious sites don't have one. So it's easier to remove it.

Closes #357