### PR TITLE
Replace all links with language-specific links

### DIFF
--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/core/models/Route.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/core/models/Route.kt
@@ -1,11 +1,14 @@
 package com.zenmo.web.zenmo.core.models
 
 import androidx.compose.runtime.Composable
-import com.varabyte.kobweb.navigation.PageMethod
 
 typealias PageComponent = @Composable () -> Unit
 
 interface Route {
+    /**
+     * Path to be passed to the router.
+     * Does not include the locale prefix such as /en/ or /nl/
+     */
     val path: String
     val pageComponent: PageComponent
 }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/core/models/RoutedMenuItem.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/core/models/RoutedMenuItem.kt
@@ -1,20 +1,20 @@
 package com.zenmo.web.zenmo.core.models
 
 import androidx.compose.runtime.Composable
-import com.varabyte.kobweb.navigation.PageMethod
 import com.zenmo.web.zenmo.core.services.localization.LocalizedText
+import com.zenmo.web.zenmo.core.services.localization.localizedUrl
 
 /**
  * A menu item that represents a route within the site
  *
  * @property label The localized label for the menu item
  * @property path The navigation path for the menu item
- * @property url The URL for the menu item, defaults to the path
+ * @property url The URL for the menu item, defaults to the path with locale prefix
  * @property pageComponent The composable function that renders the page for this route
  * */
 data class RoutedMenuItem(
     override val label: LocalizedText,
     override val path: String = label.en.asNavLinkPath(),
-    override val url: String = path,
+    override val url: String = localizedUrl(path),
     override val pageComponent: @Composable () -> Unit
 ) : NavigableMenuItem

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/core/models/SimpleMenuItem.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/core/models/SimpleMenuItem.kt
@@ -3,6 +3,10 @@ package com.zenmo.web.zenmo.core.models
 import com.zenmo.web.zenmo.core.services.localization.LocalizedText
 
 interface SimpleMenuItem {
+    /**
+     * URL ready to be passed to a Link composable or anchor element.
+     * Includes the locale prefix /en /nl if applicable.
+     */
     val url: String
     val label: LocalizedText
 }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/core/services/localization/LocalizedUrl.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/core/services/localization/LocalizedUrl.kt
@@ -1,0 +1,22 @@
+package com.zenmo.web.zenmo.core.services.localization
+
+import kotlinx.browser.window
+
+/**
+ * Prepend /en or /nl to the given path.
+ */
+fun localizedUrl(path: String): String =
+    "/${LanguageManager.language.value.shortCode}/${path.removePrefix("/")}"
+
+/**
+ * Prepend /en or /nl to the given path.
+ */
+fun localizedUrl(domain: String, path: String): String {
+    val localizedPath = localizedUrl(path)
+
+    return if (window.location.host == domain) {
+        localizedPath
+    } else {
+        "//$domain$localizedPath"
+    }
+}

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/components/CallToActionAnchorButton.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/components/CallToActionAnchorButton.kt
@@ -16,6 +16,7 @@ import com.varabyte.kobweb.silk.style.selectors.before
 import com.varabyte.kobweb.silk.style.toAttrs
 import com.varabyte.kobweb.silk.style.toModifier
 import com.zenmo.web.zenmo.components.widgets.LangText
+import com.zenmo.web.zenmo.core.services.localization.localizedUrl
 import com.zenmo.web.zenmo.domains.lux.sections.DeEmphasizedTextStyle
 import com.zenmo.web.zenmo.theme.SitePalette
 import com.zenmo.web.zenmo.theme.font.TextStyle
@@ -112,7 +113,7 @@ val LuxIconWrapperStyle = CssStyle {
 
 @Composable
 fun CallToActionAnchorButton(
-    href: String = "/book-demo",
+    href: String = localizedUrl("/book-demo"),
     subActionTextContent: @Composable () -> Unit = {
         Span(
             DeEmphasizedTextStyle.toModifier()

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/core/model/subdomain/SubdomainTwinModel.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/core/model/subdomain/SubdomainTwinModel.kt
@@ -1,8 +1,8 @@
 package com.zenmo.web.zenmo.domains.lux.core.model.subdomain
 
+import com.zenmo.web.zenmo.core.services.localization.localizedUrl
 import com.zenmo.web.zenmo.domains.lux.core.TwinModelCard
 import com.zenmo.web.zenmo.pages.SiteGlobals
-import kotlinx.browser.window
 
 
 /**
@@ -11,5 +11,5 @@ import kotlinx.browser.window
  */
 sealed interface SubdomainTwinModel : Subdomain, TwinModelCard {
     override val url: String
-        get() = "//${subdomain}.${SiteGlobals.LUX_DOMAIN}"
+        get() = localizedUrl("${subdomain}.${SiteGlobals.LUX_DOMAIN}", "/")
 }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/DrechtstedenProjectArea.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/DrechtstedenProjectArea.kt
@@ -4,12 +4,13 @@ import androidx.compose.runtime.Composable
 import com.zenmo.web.zenmo.core.models.Route
 import com.zenmo.web.zenmo.core.models.SimpleMenuItem
 import com.zenmo.web.zenmo.core.services.localization.LocalizedText
+import com.zenmo.web.zenmo.core.services.localization.localizedUrl
 
 enum class DrechtstedenProjectArea(
     override val label: LocalizedText,
     override val areaTitle: LocalizedText = label,
     override val path: String,
-    override val url: String = path,
+    override val url: String = localizedUrl(path),
     override val pageComponent: @Composable () -> Unit,
 ) : Route, SimpleMenuItem, ApplicationArea {
     RES_REGION(

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/FieldModels.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/FieldModels.kt
@@ -72,7 +72,7 @@ private fun BrowseAllModelsLink(
     applicationArea: LuxApplicationArea
 ) {
     val path = buildString {
-        append(luxModelsMenuItem.route.path)
+        append(luxModelsMenuItem.route.url)
         append("?")
         append(URLSearchParams(json("area" to applicationArea.name)))
     }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/LuxApplicationArea.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/LuxApplicationArea.kt
@@ -5,6 +5,7 @@ import com.zenmo.web.zenmo.core.models.Route
 import com.zenmo.web.zenmo.core.models.SimpleMenuItem
 import com.zenmo.web.zenmo.core.models.asNavLinkPath
 import com.zenmo.web.zenmo.core.services.localization.LocalizedText
+import com.zenmo.web.zenmo.core.services.localization.localizedUrl
 import com.zenmo.web.zenmo.domains.lux.sections.application_fields.lux_company.LuxCompany
 import com.zenmo.web.zenmo.domains.lux.sections.application_fields.lux_enegy_hub.LuxEnergyHub
 import com.zenmo.web.zenmo.domains.lux.sections.application_fields.lux_region.LuxRegion
@@ -15,7 +16,7 @@ enum class LuxApplicationArea(
     override val label: LocalizedText,
     override val areaTitle: LocalizedText = label,
     override val path: String = label.en.asNavLinkPath("application-areas"),
-    override val url: String = path,
+    override val url: String = localizedUrl(path),
     override val pageComponent: @Composable () -> Unit,
 ) : Route, SimpleMenuItem, ApplicationArea {
     LUX_ENERGY_HUB(

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/components/ApplicationAreaCTAButton.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/components/ApplicationAreaCTAButton.kt
@@ -11,6 +11,7 @@ import com.varabyte.kobweb.silk.components.navigation.UncoloredLinkVariant
 import com.varabyte.kobweb.silk.components.navigation.UndecoratedLinkVariant
 import com.zenmo.web.zenmo.components.widgets.LangText
 import com.zenmo.web.zenmo.core.services.localization.LocalizedText
+import com.zenmo.web.zenmo.core.services.localization.localizedUrl
 import com.zenmo.web.zenmo.theme.SitePalette
 import com.zenmo.web.zenmo.theme.styles.luxBorderRadius
 import org.jetbrains.compose.web.css.CSSColorValue
@@ -34,7 +35,7 @@ fun ApplicationAreaCTAButton(
     },
 ) {
     Link(
-        path = path,
+        path = localizedUrl(path),
         variant = UndecoratedLinkVariant.then(UncoloredLinkVariant),
         modifier = Modifier
             .background(bgColor).color(textColor)

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/lux_company/components/UniqueFeature.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/lux_company/components/UniqueFeature.kt
@@ -54,7 +54,7 @@ fun UniqueFeature() {
                         en = {
                             Text("A unique feature of LUX company is that it can be combined with ")
                             InlineLink(
-                                destinationUrl = LuxApplicationArea.LUX_ENERGY_HUB.path,
+                                destinationUrl = LuxApplicationArea.LUX_ENERGY_HUB.url,
                                 enLinkText = LuxApplicationArea.LUX_ENERGY_HUB.label.en,
                                 nlLinkText = LuxApplicationArea.LUX_ENERGY_HUB.label.nl
                             )
@@ -65,7 +65,7 @@ fun UniqueFeature() {
                                 "Een unieke eigenschap van LUX company is dat het gecombineerd kan worden met "
                             )
                             InlineLink(
-                                destinationUrl = LuxApplicationArea.LUX_ENERGY_HUB.path,
+                                destinationUrl = LuxApplicationArea.LUX_ENERGY_HUB.url,
                                 enLinkText = "LUX energy hub",
                                 nlLinkText = "LUX energy hub"
                             )

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/lux_region/components/LuxRegionHero.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/lux_region/components/LuxRegionHero.kt
@@ -118,7 +118,7 @@ private fun ProvenInPractice() {
     ) {
         P {
             InlineLink(
-                destinationUrl = LuxApplicationArea.LUX_ENERGY_HUB.path,
+                destinationUrl = LuxApplicationArea.LUX_ENERGY_HUB.url,
                 enLinkText = LuxApplicationArea.LUX_ENERGY_HUB.label.en,
                 nlLinkText = LuxApplicationArea.LUX_ENERGY_HUB.label.nl,
             )

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/lux_res_area/components/UniqueIntegration.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/application_fields/lux_res_area/components/UniqueIntegration.kt
@@ -58,7 +58,7 @@ fun UniqueIntegration() {
                         )
                         Text(" ")
                         InlineLink(
-                            destinationUrl = LuxApplicationArea.LUX_REGION.path,
+                            destinationUrl = LuxApplicationArea.LUX_REGION.url,
                             enLinkText = LuxApplicationArea.LUX_REGION.areaTitle.en,
                             nlLinkText = LuxApplicationArea.LUX_REGION.areaTitle.nl,
                         )
@@ -75,7 +75,7 @@ fun UniqueIntegration() {
                     nl = {
                         Text("Een unieke mogelijkheid van LUX Woonwijk is de combinatie met ")
                         InlineLink(
-                            destinationUrl = LuxApplicationArea.LUX_REGION.path,
+                            destinationUrl = LuxApplicationArea.LUX_REGION.url,
                             enLinkText = LuxApplicationArea.LUX_REGION.areaTitle.en,
                             nlLinkText = LuxApplicationArea.LUX_REGION.areaTitle.nl,
                         )

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/home/WorkWithUs.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/home/WorkWithUs.kt
@@ -14,6 +14,7 @@ import com.varabyte.kobweb.silk.components.navigation.UncoloredLinkVariant
 import com.varabyte.kobweb.silk.components.navigation.UndecoratedLinkVariant
 import com.zenmo.web.zenmo.components.widgets.LangText
 import com.zenmo.web.zenmo.components.widgets.SectionContainer
+import com.zenmo.web.zenmo.core.services.localization.localizedUrl
 import com.zenmo.web.zenmo.domains.lux.sections.LuxSectionContainerStyleVariant
 import com.zenmo.web.zenmo.domains.lux.styles.verticalLinearBackground
 import com.zenmo.web.zenmo.domains.lux.widgets.headings.HeaderText
@@ -46,7 +47,7 @@ fun WorkWithUs() {
                 )
             }
             Link(
-                path = "/book-demo",
+                path = localizedUrl("/book-demo"),
                 variant = UndecoratedLinkVariant.then(UncoloredLinkVariant),
                 modifier = Modifier
                     .background(SitePalette.light.secondary).color(Colors.Black)

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/home/faqs/Faqs.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/home/faqs/Faqs.kt
@@ -13,6 +13,7 @@ import com.varabyte.kobweb.silk.style.breakpoint.Breakpoint
 import com.varabyte.kobweb.silk.style.toModifier
 import com.zenmo.web.zenmo.components.widgets.InlineLink
 import com.zenmo.web.zenmo.components.widgets.LangBlock
+import com.zenmo.web.zenmo.core.services.localization.localizedUrl
 import com.zenmo.web.zenmo.domains.lux.sections.home.CardGridStyle
 import com.zenmo.web.zenmo.theme.SitePalette
 import com.zenmo.web.zenmo.theme.styles.LuxCornerRadius
@@ -76,9 +77,9 @@ fun FaqFallBack() {
                         "Can't find what you're looking for? ",
                     )
                     InlineLink(
+                        destinationUrl = localizedUrl("/book-demo"),
                         enLinkText = "Contact us",
                         nlLinkText = "",
-                        destinationUrl = "/book-demo",
                     )
                     Text(
                         " for support!"
@@ -89,9 +90,9 @@ fun FaqFallBack() {
                         "Kun je niet vinden wat je zoekt? ",
                     )
                     InlineLink(
+                        destinationUrl = localizedUrl("/book-demo"),
                         enLinkText = "",
                         nlLinkText = "Neem contact met ons op",
-                        destinationUrl = "/book-demo",
                     )
                     Text(
                         " voor ondersteuning!"

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/home/sections/application_areas/components/ApplicationAreaCard.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/home/sections/application_areas/components/ApplicationAreaCard.kt
@@ -93,7 +93,7 @@ fun ApplicationAreaCard(
         }
 
         Link(
-            path = applicationArea.path,
+            path = applicationArea.url,
             variant = UncoloredLinkVariant.then(UndecoratedLinkVariant),
         ) {
             Row(

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/nav_header/LuxLogo.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/nav_header/LuxLogo.kt
@@ -15,8 +15,8 @@ import com.varabyte.kobweb.silk.components.navigation.UncoloredLinkVariant
 import com.varabyte.kobweb.silk.components.navigation.UndecoratedLinkVariant
 import com.varabyte.kobweb.silk.style.breakpoint.Breakpoint
 import com.varabyte.kobweb.silk.style.extendedBy
+import com.zenmo.web.zenmo.core.services.localization.localizedUrl
 import com.zenmo.web.zenmo.pages.SiteGlobals
-import kotlinx.browser.window
 import org.jetbrains.compose.web.css.DisplayStyle
 import org.jetbrains.compose.web.css.px
 
@@ -61,11 +61,8 @@ val LuxLogoImageVariant = FitWidthImageVariant.extendedBy {
 fun LuxLogo(
     domain: String = SiteGlobals.LUX_DOMAIN
 ) {
-    val location = window.location
-    val sameOrigin = location.hostname == domain
-
     Link(
-        path = if (sameOrigin) "/" else "${location.protocol}//$domain",
+        path = localizedUrl(domain, "/"),
         variant = UndecoratedLinkVariant.then(UncoloredLinkVariant),
         openExternalLinksStrategy = OpenLinkStrategy.IN_PLACE
     ) {

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/nav_header/NavBar.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/nav_header/NavBar.kt
@@ -45,9 +45,9 @@ fun NavBar() {
                 when (menuItem) {
                     is MenuItem.Simple -> {
                         LuxMenuItem(
-                            href = menuItem.route.path,
+                            href = menuItem.route.url,
                             menuTitle = menuItem.route.label,
-                            isActive = isPathActive(href = menuItem.route.path),
+                            isActive = isPathActive(href = menuItem.route.url),
                         )
                     }
 

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/nav_header/components/MenuSectionItem.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/nav_header/components/MenuSectionItem.kt
@@ -118,7 +118,7 @@ val SubMenuAppearanceAnimKeyFrames = Keyframes {
 
 @Composable
 fun LuxMenuItemWithSubs(titleText: LocalizedText, subItems: List<MenuItem.Simple>) {
-    val isMenuActive = subItems.any { isPathActive(href = it.route.path) }
+    val isMenuActive = subItems.any { isPathActive(href = it.route.url) }
 
     Box(
         modifier = MenuItemParentStyle.toModifier()
@@ -164,9 +164,9 @@ fun LuxMenuItemWithSubs(titleText: LocalizedText, subItems: List<MenuItem.Simple
                         .width(400.px).toAttrs()
                 ) {
                     subItems.forEach { subItem ->
-                        val isActive = isPathActive(href = subItem.route.path)
+                        val isActive = isPathActive(href = subItem.route.url)
                         LuxMenuItem(
-                            href = subItem.route.path,
+                            href = subItem.route.url,
                             menuTitle = subItem.route.label,
                             subText = subItem.descriptionParagraph,
                             isActive = isActive,

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/nav_header/components/SideMenu.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/nav_header/components/SideMenu.kt
@@ -113,9 +113,9 @@ fun SideMenu(
                         when (item) {
                             is MenuItem.Simple ->
                                 SideMenuItem(
-                                    href = item.route.path,
+                                    href = item.route.url,
                                     label = item.route.label,
-                                    isActive = isPathActive(href = item.route.path),
+                                    isActive = isPathActive(href = item.route.url),
                                 )
 
                             is MenuItem.WithSubs -> {
@@ -134,9 +134,9 @@ fun SideMenu(
                                     ) {
                                         item.subItems.forEach { subItem ->
                                             SideMenuItem(
-                                                href = subItem.route.path,
+                                                href = subItem.route.url,
                                                 label = subItem.route.label,
-                                                isActive = isPathActive(href = subItem.route.path),
+                                                isActive = isPathActive(href = subItem.route.url),
                                             )
                                         }
                                     }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/nav_header/luxNavMenu.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/sections/nav_header/luxNavMenu.kt
@@ -13,6 +13,7 @@ private val applicationAreasMenuItem = MenuItem.WithSubs(
         MenuItem.Simple(
             route = RoutedMenuItem(
                 path = field.path,
+                url = field.url,
                 label = field.label,
                 pageComponent = field.pageComponent,
             ),

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/DrechtstedenTwinModel.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/drechtsteden/DrechtstedenTwinModel.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import com.zenmo.web.zenmo.core.models.Route
 import com.zenmo.web.zenmo.core.models.RoutedMenuItem
 import com.zenmo.web.zenmo.core.services.localization.LocalizedText
+import com.zenmo.web.zenmo.core.services.localization.localizedUrl
 import com.zenmo.web.zenmo.domains.lux.core.PrivateTwinModel
 import com.zenmo.web.zenmo.domains.lux.core.TwinModelCard
 import com.zenmo.web.zenmo.domains.lux.core.model.subdomain.PrivateSubdomainModel
@@ -26,12 +27,7 @@ data class DrechtstedenTwinModel(
     override val pageComponent: @Composable () -> Unit,
 ) : Route, TwinModelCard, PrivateTwinModel {
     override val url: String
-        get() = if (isCurrentDomainDrechtsteden) {
-            // Using only the path prevents a full page reload when navigating
-            path
-        } else {
-            "//${drechtstedenFullDomain}$path"
-        }
+        get() = localizedUrl(drechtstedenFullDomain, path)
 }
 
 fun DrechtstedenTwinModel.asRoutedMenuItem() =

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/zenmo/sections/nav_header/components/ExpandableSideMenuItem.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/zenmo/sections/nav_header/components/ExpandableSideMenuItem.kt
@@ -106,9 +106,9 @@ fun ExpandableSideMenuItem(
             ) {
                 menu.subItems.forEach { subItem ->
                     SideMenuNavLink(
-                        href = subItem.route.path,
+                        href = subItem.route.url,
                         label = subItem.route.label,
-                        isActive = isPathActive(href = subItem.route.path),
+                        isActive = isPathActive(href = subItem.route.url),
                         onClick = onClick,
                         hasBullet = true
                     )

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/zenmo/sections/nav_header/components/NavBar.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/zenmo/sections/nav_header/components/NavBar.kt
@@ -44,9 +44,9 @@ fun NavBar(
             when (item) {
                 is MenuItem.Simple -> {
                     NavBarLink(
-                        href = item.route.path,
+                        href = item.route.url,
                         label = item.route.label,
-                        isActive = isPathActive(href = item.route.path),
+                        isActive = isPathActive(href = item.route.url),
                     )
                 }
 

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/zenmo/sections/nav_header/components/SideMenu.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/zenmo/sections/nav_header/components/SideMenu.kt
@@ -102,9 +102,9 @@ fun SideMenu(
                         when (item) {
                             is MenuItem.Simple -> {
                                 SideMenuNavLink(
-                                    href = item.route.path,
+                                    href = item.route.url,
                                     label = item.route.label,
-                                    isActive = isPathActive(href = item.route.path),
+                                    isActive = isPathActive(href = item.route.url),
                                     onClick = { close() }
                                 )
                             }
@@ -113,7 +113,7 @@ fun SideMenu(
                                 ExpandableSideMenuItem(
                                     menu = item,
                                     isAnySubItemActive = item.subItems.any { subItem ->
-                                        isPathActive(href = subItem.route.path)
+                                        isPathActive(href = subItem.route.url)
                                     },
                                     onClick = { close() }
                                 )

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/zenmo/widgets/MenuItemWithSubs.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/zenmo/widgets/MenuItemWithSubs.kt
@@ -28,7 +28,7 @@ val MainMenuItemHoverStyle = CssStyle {
 fun MenuItemWithSubs(
     menu: MenuItem.WithSubs,
 ) {
-    val isMenuActive = menu.subItems.any { isPathActive(href = it.route.path) }
+    val isMenuActive = menu.subItems.any { isPathActive(href = it.route.url) }
     Box(
         modifier = MenuItemParentStyle.toModifier()
     ) {
@@ -48,9 +48,9 @@ fun MenuItemWithSubs(
                     contentAlignment = Alignment.Center
                 ) {
                     NavBarLink(
-                        href = sub.route.path,
+                        href = sub.route.url,
                         label = sub.route.label,
-                        isActive = isPathActive(href = sub.route.path),
+                        isActive = isPathActive(href = sub.route.url),
                     )
                 }
             }


### PR DESCRIPTION
Introduce the convention that "path" is a non-localized path and "url"
is the localized version.