### PR TITLE
Remove stale status from protected model wrapper

### DIFF
--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/components/ModelWrapper.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/domains/lux/subdomains/private_subdomains/components/ModelWrapper.kt
@@ -1,6 +1,6 @@
 package com.zenmo.web.zenmo.domains.lux.subdomains.private_subdomains.components
 
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
 import com.varabyte.kobweb.compose.css.BoxSizing
 import com.varabyte.kobweb.compose.css.ObjectFit
 import com.varabyte.kobweb.compose.css.functions.blur
@@ -80,7 +80,6 @@ fun ModelWrapper(
     entryPoint: String,
     modifier: Modifier = Modifier.padding(topBottom = 3.cssRem)
 ) {
-    var wrapperStatus by remember { mutableStateOf<AccessStatus>(AccessStatus.Success) }
     Box(
         Modifier
             .fillMaxWidth()
@@ -88,40 +87,33 @@ fun ModelWrapper(
             .height(80.vh).then(modifier),
         contentAlignment = Alignment.Center
     ) {
-        if (wrapperStatus !is AccessStatus.Success) {
-            Image(
-                src = imgUrl,
-                alt = "$entryPoint model teaser",
-                modifier = BlurModelImageStyle.toModifier()
-            )
-        }
-        Div(
-            Modifier
-                .thenIf(wrapperStatus !is AccessStatus.Success, ProtectedWrapperStyle.toModifier())
-                .thenIf(wrapperStatus is AccessStatus.Success, ModelWrapperStyle.toModifier())
-                .toAttrs()
-        ) {
-            ProtectedWrapper(
-                entryPoint = entryPoint,
-                fallbackContent = { status ->
-                    // we don't need to recompose the content if the status hasn't changed
-                    if (wrapperStatus != status) {
-                        wrapperStatus = status
+        ProtectedWrapper(
+            entryPoint = entryPoint,
+            display = { status ->
+                if (status is AccessStatus.Success) {
+                    Div(ModelWrapperStyle.toModifier().toAttrs()) {
+                        status.protectedComponent()
                     }
-
-                    when (status) {
-                        AccessStatus.Pending -> Pending()
-                        AccessStatus.NotLoggedIn -> Login()
-                        AccessStatus.NotEnoughPrivileges -> NotEnoughPrivileges(actionContent = {})
-                        is AccessStatus.Error -> {
-                            ErrorWidget(errorMessage = status.errorMessage, actionContent = {
-                                // todo trigger a retry or something
-                            })
+                } else {
+                    Image(
+                        src = imgUrl,
+                        alt = "$entryPoint model teaser",
+                        modifier = BlurModelImageStyle.toModifier()
+                    )
+                    Div(ProtectedWrapperStyle.toModifier().toAttrs()) {
+                        when (status) {
+                            AccessStatus.Pending -> Pending()
+                            AccessStatus.NotLoggedIn -> Login()
+                            AccessStatus.NotEnoughPrivileges -> NotEnoughPrivileges(actionContent = {})
+                            is AccessStatus.Error -> {
+                                ErrorWidget(errorMessage = status.errorMessage, actionContent = {
+                                    // todo trigger a retry or something
+                                })
+                            }
                         }
-
-                        AccessStatus.Success -> {}
                     }
-                })
-        }
+                }
+            },
+        )
     }
 }

--- a/site/src/jsMain/kotlin/com/zenmo/web/zenmo/protected/ProtectedWrapper.kt
+++ b/site/src/jsMain/kotlin/com/zenmo/web/zenmo/protected/ProtectedWrapper.kt
@@ -23,37 +23,44 @@ sealed class AccessStatus {
     data object NotLoggedIn : AccessStatus()
     data object NotEnoughPrivileges : AccessStatus()
     data class Error(val errorMessage: String) : AccessStatus()
-    data object Success : AccessStatus()
+    data class Success(val protectedComponent: @Composable () -> Unit) : AccessStatus()
+}
+
+typealias ProtectedDisplayComponent = @Composable (
+    status: AccessStatus,
+) -> Unit
+
+@Composable
+fun DefaultProtectedDisplay(status: AccessStatus) {
+    when (status) {
+        AccessStatus.Pending -> Pending()
+        AccessStatus.NotLoggedIn -> Login()
+        AccessStatus.NotEnoughPrivileges -> NotEnoughPrivileges()
+        is AccessStatus.Error -> {
+            ErrorWidget(errorMessage = status.errorMessage)
+        }
+        is AccessStatus.Success -> {
+            status.protectedComponent()
+        }
+    }
 }
 
 @Composable
 fun ProtectedWrapper(
     entryPoint: String,
-    fallbackContent: @Composable (AccessStatus) -> Unit = {
-        when (it) {
-            AccessStatus.Pending -> Pending()
-            AccessStatus.NotLoggedIn -> Login()
-            AccessStatus.NotEnoughPrivileges -> NotEnoughPrivileges()
-            is AccessStatus.Error -> {
-                ErrorWidget(errorMessage = it.errorMessage)
-            }
-
-            AccessStatus.Success -> {} // does not happen here, self-contained in the module
-        }
-    }
+    display: ProtectedDisplayComponent = { status -> DefaultProtectedDisplay(status) },
 ) {
-    var privateModule by remember { mutableStateOf<PrivateTextModule?>(null) }
     var status by remember { mutableStateOf<AccessStatus>(AccessStatus.Pending) }
 
     LaunchedEffect(Unit) {
         try {
             val entryPointParts = entryPoint.split("/")
-            privateModule =
+            val privateModule =
                 when (entryPointParts.size) {
                     3 -> importAsync<PrivateTextModule>("./entrypoints/${entryPointParts[0]}/${entryPointParts[1]}/${entryPointParts[2]}/ProtectedComponent.export.mjs").await()
                     else -> importAsync<PrivateTextModule>("./entrypoints/$entryPoint/ProtectedComponent.export.mjs").await()
                 }
-            status = AccessStatus.Success
+            status = AccessStatus.Success { privateModule.ProtectedComponent() }
         } catch (e: Throwable) {
             /**
              * We get no status code after import failure.
@@ -101,9 +108,6 @@ fun ProtectedWrapper(
         Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center
     ) {
-        when (status) {
-            AccessStatus.Success -> privateModule!!.ProtectedComponent()
-            else -> fallbackContent(status)
-        }
+        display(status)
     }
 }


### PR DESCRIPTION
ModelWrapper kept a copy of the status of ProtectedWrapper but it was
not kept in sync. This change removes this status and makes more use
of higher-order components which have the status as an argument.

Fixes #489