### PR TITLE
make ProtectedComponent accept modelId as parameter

### DIFF
--- a/site/src/jsMain/kotlin/domains/lux/core/model/subdomain/PrivateSubdomainModel.kt
+++ b/site/src/jsMain/kotlin/domains/lux/core/model/subdomain/PrivateSubdomainModel.kt
@@ -34,6 +34,7 @@ enum class PrivateSubdomainModel(
         label = LocalizedText(nl = "Genius"),
         imageUrl = "/lux/images/model_thumbnails/GENIUS5.jpg",
         entryPoint = "genius",
+        modelId = Uuid.parse("42e7ad8d-102f-4a32-808c-65bdd646a52a"),
         applicationArea = LuxApplicationArea.LUX_ENERGY_HUB
     ),
     HESSENPOORT(
@@ -42,6 +43,7 @@ enum class PrivateSubdomainModel(
         label = LocalizedText(nl = "Hessenpoort"),
         imageUrl = "/lux/images/model_thumbnails/Hessenpoort2.jpg",
         entryPoint = "hessenpoort",
+        modelId = Uuid.parse("ebade042-5518-4162-8eb5-f55439c67c64"),
         applicationArea = LuxApplicationArea.LUX_ENERGY_HUB
     ),
     KAS_ALS_ENERGIEBRON(
@@ -50,6 +52,7 @@ enum class PrivateSubdomainModel(
         label = LocalizedText(nl = "Kas Als Energiebron"),
         imageUrl = "/lux/images/model_thumbnails/kasalsenergiebron6.jpg",
         entryPoint = "kasalsenergiebron",
+        modelId = Uuid.parse("7dfd7bdd-9882-4c58-bfc2-5aa6e5aac938"),
         applicationArea = LuxApplicationArea.LUX_ENERGY_HUB
     ),
     PREZERO(
@@ -58,6 +61,7 @@ enum class PrivateSubdomainModel(
         label = LocalizedText(nl = "PreZero"),
         imageUrl = "/lux/images/model_thumbnails/ModelThumbnailPreZero.png",
         entryPoint = "prezero",
+        modelId = Uuid.parse("72d47601-ffb6-4b66-b7a1-81cb289c6f4e"),
         applicationArea = LuxApplicationArea.LUX_BUSINESS
     ),
     BORCHWERF(
@@ -66,6 +70,7 @@ enum class PrivateSubdomainModel(
         label = LocalizedText(nl = "Borchwerf"),
         imageUrl = "/lux/images/model_thumbnails/borchwerf.png",
         entryPoint = "borchwerf",
+        modelId = Uuid.parse("0ef687d2-3227-47da-b9e1-5ea5751af17d"),
         applicationArea = LuxApplicationArea.LUX_ENERGY_HUB,
     ),
     DE_WIEKEN(
@@ -74,6 +79,7 @@ enum class PrivateSubdomainModel(
         label = LocalizedText(nl = "De Wieken"),
         imageUrl = "/lux/images/model_thumbnails/dewieken.png",
         entryPoint = "dewieken",
+        modelId = Uuid.parse("784ed110-8b2c-4bcf-be75-54f69d278ec6"),
         applicationArea = LuxApplicationArea.LUX_ENERGY_HUB,
     ),
     VAANPARK(
@@ -82,6 +88,7 @@ enum class PrivateSubdomainModel(
         label = LocalizedText(nl = "Vaanpark"),
         imageUrl = "/lux/images/model_thumbnails/vaanpark.png",
         entryPoint = "vaanpark",
+        modelId = Uuid.parse("b72013ef-c6b4-4171-afef-754e547b723f"),
         applicationArea = LuxApplicationArea.LUX_ENERGY_HUB,
     ),
     BIJSTERHUIZEN(
@@ -90,6 +97,7 @@ enum class PrivateSubdomainModel(
         label = LocalizedText(nl = "Bijsterhuizen"),
         imageUrl = "/lux/images/model_thumbnails/bijsterhuizen.png",
         entryPoint = "bijsterhuizen",
+        modelId = Uuid.parse("66624cc5-eb5e-447e-82bf-9b0fa1bfcf7d"),
         applicationArea = LuxApplicationArea.LUX_ENERGY_HUB,
     ),
     OSS(

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/Bijsterhuizen.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/Bijsterhuizen.kt
@@ -22,6 +22,7 @@ fun Bijsterhuizen() {
         PrivateTwinModelPage(
             entryPoint = bijsterhuizen.entryPoint,
             imageUrl = "/lux/images/models/bijsterhuizen.png",
+            modelId = bijsterhuizen.modelId,
             introContent = {
                 MediaContentLayout(
                     imageUrl = bijsterhuizen.imageUrl,

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/Borchwerf.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/Borchwerf.kt
@@ -20,6 +20,7 @@ fun Borchwerf() {
     ) {
         PrivateTwinModelPage(
             entryPoint = borchwerf.entryPoint,
+            modelId = borchwerf.modelId,
             imageUrl = "/lux/images/models/borchwerf.png",
             introContent = {
                 MediaContentLayout(

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/DeWieken.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/DeWieken.kt
@@ -20,6 +20,7 @@ fun DeWieken() {
     ) {
         PrivateTwinModelPage(
             entryPoint = deWieken.entryPoint,
+            modelId = deWieken.modelId,
             imageUrl = "/lux/images/dewieken.png",
             introContent = {
                 MediaContentLayout(

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/Hessenpoort.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/Hessenpoort.kt
@@ -27,6 +27,7 @@ fun Hessenpoort() {
     ) {
         PrivateTwinModelPage(
             entryPoint = hessenpoort.entryPoint,
+            modelId = hessenpoort.modelId,
             imageUrl = "/lux/images/models/hessenpoort.png",
             introContent = {
                 MediaContentLayout(

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/KasAlsEnergiebron.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/KasAlsEnergiebron.kt
@@ -27,6 +27,7 @@ fun KasAlsEnergiebron() {
     ) {
         PrivateTwinModelPage(
             entryPoint = kasAlsEnergiebron.entryPoint,
+            modelId = kasAlsEnergiebron.modelId,
             imageUrl = "/lux/images/models/kasals.png",
             introContent = {
                 MediaContentLayout(

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/PreZero.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/PreZero.kt
@@ -21,6 +21,7 @@ fun PreZero() {
     ) {
         PrivateTwinModelPage(
             entryPoint = prezero.entryPoint,
+            modelId = prezero.modelId,
             imageUrl = "/lux/images/models/prezero.png",
             introContent = {
                 MediaContentLayout(

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/Vaanpark.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/Vaanpark.kt
@@ -20,6 +20,7 @@ fun Vaanpark() {
     ) {
         PrivateTwinModelPage(
             entryPoint = vaanpark.entryPoint,
+            modelId = vaanpark.modelId,
             imageUrl = "/lux/images/vaanpark.png",
             introContent = {
                 MediaContentLayout(

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/components/ModelWrapper.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/components/ModelWrapper.kt
@@ -14,16 +14,13 @@ import com.varabyte.kobweb.silk.style.base
 import com.varabyte.kobweb.silk.style.breakpoint.Breakpoint
 import com.varabyte.kobweb.silk.style.toModifier
 import energy.lux.frontend.components.widgets.ErrorWidget
-import energy.lux.frontend.protected.AccessStatus
-import energy.lux.frontend.protected.Login
-import energy.lux.frontend.protected.NotEnoughPrivileges
-import energy.lux.frontend.protected.Pending
-import energy.lux.frontend.protected.ProtectedWrapper
+import energy.lux.frontend.protected.*
 import energy.lux.frontend.theme.isZenmoDomain
 import energy.lux.frontend.theme.styles.LuxCornerRadius
 import energy.lux.frontend.theme.styles.luxBorderRadius
 import org.jetbrains.compose.web.css.*
 import org.jetbrains.compose.web.dom.Div
+import kotlin.uuid.Uuid
 
 val ProtectedWrapperStyle = CssStyle {
     base {
@@ -82,6 +79,7 @@ val ModelWrapperStyle = CssStyle.base {
 fun ModelWrapper(
     imgUrl: String,
     entryPoint: String,
+    modelId: Uuid,
     modifier: Modifier = Modifier.padding(topBottom = 3.cssRem)
 ) {
     Box(
@@ -93,10 +91,11 @@ fun ModelWrapper(
     ) {
         ProtectedWrapper(
             entryPoint = entryPoint,
+            props = modelId,
             display = { status ->
                 if (status is AccessStatus.Success) {
                     Div(ModelWrapperStyle.toModifier().toAttrs()) {
-                        status.protectedComponent()
+                        status.protectedComponent(status.props)
                     }
                 } else {
                     Image(

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/components/PrivateTwinModelPage.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/components/PrivateTwinModelPage.kt
@@ -8,7 +8,7 @@ import kotlin.uuid.Uuid
 fun PrivateTwinModelPage(
     entryPoint: String,
     imageUrl: String,
-    modelId: Uuid = Uuid.NIL,
+    modelId: Uuid,
     introContent: @Composable () -> Unit = {},
     mediaContent: @Composable () -> Unit = {},
     extraContent: @Composable () -> Unit = {},

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/components/PrivateTwinModelPage.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/components/PrivateTwinModelPage.kt
@@ -8,18 +8,20 @@ import kotlin.uuid.Uuid
 fun PrivateTwinModelPage(
     entryPoint: String,
     imageUrl: String,
+    modelId: Uuid = Uuid.NIL,
     introContent: @Composable () -> Unit = {},
     mediaContent: @Composable () -> Unit = {},
     extraContent: @Composable () -> Unit = {},
     footerContent: @Composable () -> Unit,
 ) = SubdomainModelPage(
-    modelId = Uuid.NIL,
+    modelId = modelId,
     introContent = introContent,
     mediaContent = mediaContent,
     anylogicRender = {
         ModelWrapper(
             imgUrl = imageUrl,
             entryPoint = entryPoint,
+            modelId = modelId,
         )
     },
     extraContent = extraContent,

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/drechtsteden/components/DrechtstedenTwinModelPage.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/drechtsteden/components/DrechtstedenTwinModelPage.kt
@@ -23,7 +23,7 @@ fun DrechtstedenTwinModelPage(
     mediaContent: @Composable () -> Unit = {},
     footerContent: @Composable () -> Unit,
 ) = SubdomainModelPage(
-    modelId = Uuid.NIL,
+    modelId = twin.modelId,
     introContent = {
         Column(
             Modifier.fillMaxWidth()

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/drechtsteden/components/DrechtstedenTwinModelPage.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/drechtsteden/components/DrechtstedenTwinModelPage.kt
@@ -49,6 +49,7 @@ fun DrechtstedenTwinModelPage(
                 ModelWrapper(
                     imgUrl = twin.imageUrl,
                     entryPoint = twin.entryPoint,
+                    modelId = twin.modelId,
                 )
             }
         }

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/drechtstedenBusinessParkModels.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/drechtsteden/pages/businessparks/drechtstedenBusinessParkModels.kt
@@ -2,12 +2,14 @@ package energy.lux.frontend.domains.lux.subdomains.private_subdomains.drechtsted
 
 import energy.lux.frontend.core.services.localization.LocalizedText
 import energy.lux.frontend.domains.lux.subdomains.private_subdomains.drechtsteden.DrechtstedenTwinModel
+import kotlin.uuid.Uuid
 
 val ambachtseZoom =
     DrechtstedenTwinModel(
         projectPath = "/ambachtsezoom",
         label = LocalizedText(nl = "Energy Twin Ambachtse Zoom"),
         entryPoint = "drechtsteden/businessparks/ambachtse",
+        modelId = Uuid.parse("fc8e83f5-2c0d-4961-b4f9-35069486eca6"),
         imageUrl = "/lux/images/drechtsteden/business-parks/ambachtsezoom.png",
         pageComponent = { AmbachtsePage() }
     )
@@ -16,6 +18,7 @@ val amstelwijckBusinesspark =
         projectPath = "/amstelwijckbusinesspark",
         label = LocalizedText(nl = "Energy Twin Amstelwijck Businesspark"),
         entryPoint = "drechtsteden/businessparks/amstelwijck",
+        modelId = Uuid.parse("266253e0-16b4-44de-baac-51641f99e34b"),
         imageUrl = "/lux/images/drechtsteden/business-parks/Amstelwijck_businesspark_foto.png",
         pageComponent = { AmstelwijckPage() }
     )
@@ -24,6 +27,7 @@ val antoniapolder =
         projectPath = "/antoniapolder",
         label = LocalizedText(nl = "Energy Twin Antoniapolder"),
         entryPoint = "drechtsteden/businessparks/antoniapolder",
+        modelId = Uuid.parse("4f86e085-34f3-4b45-891b-8c9789711a91"),
         imageUrl = "/lux/images/drechtsteden/business-parks/antoniapolder.png",
         pageComponent = { AntoniapolderPage() }
     )
@@ -32,6 +36,7 @@ val bakestein =
         projectPath = "/bakestein",
         label = LocalizedText(nl = "Energy Twin Bakestein"),
         entryPoint = "drechtsteden/businessparks/bakestein",
+        modelId = Uuid.parse("19fcb3e6-bfaa-4f22-81b3-701b36456acc"),
         imageUrl = "/lux/images/drechtsteden/business-parks/bakestein.png",
         pageComponent = { BakesteinPage() }
     )
@@ -40,6 +45,7 @@ val deGeer =
         projectPath = "/degeer",
         label = LocalizedText(nl = "Energy Twin De Geer"),
         entryPoint = "drechtsteden/businessparks/degeer",
+        modelId = Uuid.parse("f8ceaf4d-5d2e-48e6-8b7e-e95874c0d1a3"),
         imageUrl = "/lux/images/drechtsteden/business-parks/de_geer.png",
         pageComponent = { DeGeerPage() }
     )
@@ -48,6 +54,7 @@ val deStaart =
         projectPath = "/destaart",
         label = LocalizedText(nl = "Energy Twin De Staart"),
         entryPoint = "drechtsteden/businessparks/destaart",
+        modelId = Uuid.parse("b2275ee1-18bb-46d8-9e40-5b45b0295b33"),
         imageUrl = "/lux/images/drechtsteden/business-parks/de-staart.jpg",
         pageComponent = { DeStaartPage() }
     )
@@ -56,6 +63,7 @@ val dordtseKil12AmstelwijckWest =
         projectPath = "/dordtsekil12amstelwijckwest",
         label = LocalizedText(nl = "Energy Twin Dordtse Kil I & II en Amstelwijck West"),
         entryPoint = "drechtsteden/businessparks/dordtseamstelwijck",
+        modelId = Uuid.parse("1e473aa2-0581-4584-82cd-1b2d0507d274"),
         imageUrl = "/lux/images/drechtsteden/business-parks/dordtsekil12enAmstelwijckWest_foto.png",
         pageComponent = { DordtseKilIPage() }
     )
@@ -64,6 +72,7 @@ val dordtseKil34 =
         projectPath = "/dordtsekil34",
         label = LocalizedText(nl = "Energy Twin Dordtse Kil III & IV"),
         entryPoint = "drechtsteden/businessparks/dordtse",
+        modelId = Uuid.parse("2f9547eb-e123-4f92-9351-85f739a27ae8"),
         imageUrl = "/lux/images/drechtsteden/business-parks/dordtsekil34.png",
         pageComponent = { DordtseKilIIIPage() }
     )
@@ -72,6 +81,7 @@ val grooteLindtV2 =
         projectPath = "/grootelindtv2",
         label = LocalizedText(nl = "Energy Twin Groote Lindt v2"),
         entryPoint = "drechtsteden/businessparks/groote",
+        modelId = Uuid.parse("96a551f4-8e56-4fc5-8b5c-babfddf92ac4"),
         imageUrl = "/lux/images/drechtsteden/business-parks/Groote-Lindt.png",
         pageComponent = { LindtPage() }
     )
@@ -80,6 +90,7 @@ val leerpark =
         projectPath = "/leerpark",
         label = LocalizedText(nl = "Energy Twin Leerpark"),
         entryPoint = "drechtsteden/businessparks/leerpark",
+        modelId = Uuid.parse("54711b02-60db-4336-b20a-b7ac9940b3dc"),
         imageUrl = "/lux/images/drechtsteden/business-parks/Leerpark_foto.png",
         pageComponent = { LeerparkPage() }
     )
@@ -88,6 +99,7 @@ val nieuweWeg =
         projectPath = "/nieuweweg",
         label = LocalizedText(nl = "Energy Twin Nieuwe Weg"),
         entryPoint = "drechtsteden/businessparks/nieuweweg",
+        modelId = Uuid.parse("57f0e77f-b609-4487-badc-9167e53f6a24"),
         imageUrl = "/lux/images/drechtsteden/business-parks/FeaturedImageNieuweWegPagina.png",
         pageComponent = { NieuweWegPage() }
     )
@@ -96,6 +108,7 @@ val papendrechtOosteind =
         projectPath = "/papendrechtoosteind",
         label = LocalizedText(nl = "Energy Twin Papendrecht Oosteind"),
         entryPoint = "drechtsteden/businessparks/papendrechtoosteind",
+        modelId = Uuid.parse("0ef34b9d-4887-451c-bb51-2d991b8f07ff"),
         imageUrl = "/lux/images/drechtsteden/business-parks/papendrecht_oosteind.png",
         pageComponent = { PapendrechtPage() }
     )
@@ -104,6 +117,7 @@ val sliedrechtBusinesspark =
         projectPath = "/sliedrechtbusinesspark",
         label = LocalizedText(nl = "Energy Twin Sliedrecht"),
         entryPoint = "drechtsteden/businessparks/sliedrecht",
+        modelId = Uuid.parse("51df1e41-81ed-48a3-af5c-631a74f5cabf"),
         imageUrl = "/lux/images/drechtsteden/business-parks/FeaturedImageSliedrechtPagina.png",
         pageComponent = { SliedrechtPage() }
     )

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/drechtsteden/pages/municipalities/drechtstedenMunicipalityModels.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/drechtsteden/pages/municipalities/drechtstedenMunicipalityModels.kt
@@ -2,6 +2,7 @@ package energy.lux.frontend.domains.lux.subdomains.private_subdomains.drechtsted
 
 import energy.lux.frontend.core.services.localization.LocalizedText
 import energy.lux.frontend.domains.lux.subdomains.private_subdomains.drechtsteden.DrechtstedenTwinModel
+import kotlin.uuid.Uuid
 
 
 val alblasserdam =
@@ -9,6 +10,7 @@ val alblasserdam =
         projectPath = "/alblasserdam",
         label = LocalizedText(nl = "Energy Twin Gemeente Alblasserdam"),
         entryPoint = "drechtsteden/municipalities/alblasserdam",
+        modelId = Uuid.parse("92e0993d-e96d-4f05-9c0b-eb9bbf1d1eb1"),
         imageUrl = "/lux/images/drechtsteden/municipalities/Gemeente_Alblasserdam_foto.png",
         pageComponent = { GemeenteAlblasserdamPage() }
     )
@@ -18,6 +20,7 @@ val hardinxveld =
         projectPath = "/hardinxveld",
         label = LocalizedText(nl = "Energy Twin Gemeente Hardinxveld-Giessendam"),
         entryPoint = "drechtsteden/municipalities/hardinxveld",
+        modelId = Uuid.parse("87d8b189-bcc4-4e37-ba44-3ee1e242985a"),
         imageUrl = "/lux/images/drechtsteden/municipalities/Gemeente_Hardinxveld-Giessendam_foto.png",
         pageComponent = { HardinxveldPage() }
     )
@@ -26,6 +29,7 @@ val sliedrechtMunicipality =
         projectPath = "/sliedrechtmunicipality",
         label = LocalizedText(nl = "Energy Twin Gemeente Sliedrecht"),
         entryPoint = "drechtsteden/municipalities/sliedrecht",
+        modelId = Uuid.parse("e62f7668-a52c-47d2-aae6-e89717ddb5a7"),
         imageUrl = "/lux/images/drechtsteden/municipalities/Gemeente_Sliedrecht_foto.png",
         pageComponent = { GemeenteSliedrechtPage() }
     )
@@ -34,6 +38,7 @@ val dordrecht =
         projectPath = "/dordrecht",
         label = LocalizedText(nl = "Energy Twin Dordrecht"),
         entryPoint = "drechtsteden/municipalities/dordrecht",
+        modelId = Uuid.parse("ccc42e85-3ae9-4025-bb98-a34a29adb18a"),
         imageUrl = "/lux/images/drechtsteden/municipalities/dordrecht.png",
         pageComponent = { Dordrecht() }
     )
@@ -42,6 +47,7 @@ val papendrecht =
         projectPath = "/papendrecht",
         label = LocalizedText(nl = "Energy Twin Papendrecht"),
         entryPoint = "drechtsteden/municipalities/papendrecht",
+        modelId = Uuid.parse("af3272d6-b1a4-49a2-af86-e3f55cc731d9"),
         imageUrl = "/lux/images/drechtsteden/municipalities/papendrecht.png",
         pageComponent = { Papendrecht() }
     )
@@ -50,6 +56,7 @@ val zwijndrecht =
         projectPath = "/zwijndrecht",
         label = LocalizedText(nl = "Energy Twin Zwijndrecht"),
         entryPoint = "drechtsteden/municipalities/zwijndrecht",
+        modelId = Uuid.parse("a4c15d4b-025a-4169-b948-3ddd75c67091"),
         imageUrl = "/lux/images/drechtsteden/municipalities/zwijndrecht.png",
         pageComponent = { Zwijndrecht() }
     )
@@ -58,6 +65,7 @@ val hendrikIdoAmbacht =
         projectPath = "/hendrikidoambacht",
         label = LocalizedText(nl = "Energy Twin Hendrik-Ido-Ambacht"),
         entryPoint = "drechtsteden/municipalities/hendrikidoambacht",
+        modelId = Uuid.parse("95110865-7aca-4a5f-9934-ef5f1891ebd9"),
         imageUrl = "/lux/images/drechtsteden/municipalities/hendrik_ido_ambacht.png",
         pageComponent = { HendrikIdoAmbacht() }
     )

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/drechtsteden/pages/resneighborhoods/drechtstedenResNeighborhoodsModels.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/drechtsteden/pages/resneighborhoods/drechtstedenResNeighborhoodsModels.kt
@@ -12,6 +12,7 @@ val overTSpoor =
         label = LocalizedText(nl = "Energy Twin Over 't Spoor"),
         applicationArea = LuxApplicationArea.LUX_NEIGHBOURHOOD,
         entryPoint = "drechtsteden/resneighborhoods/overtspoor",
+        modelId = Uuid.parse("612143ff-eedc-4f36-8606-13d4c4d710a7"),
         imageUrl = "/lux/images/drechtsteden/resneighborhoods/over_t_spoor.png",
         pageComponent = { OverTSpoor() }
     )
@@ -21,6 +22,7 @@ val oostdonk =
         label = LocalizedText(nl = "Energy Twin Oostdonk"),
         applicationArea = LuxApplicationArea.LUX_NEIGHBOURHOOD,
         entryPoint = "drechtsteden/resneighborhoods/oostdonk",
+        modelId = Uuid.parse("3b4289ea-d2b8-4887-95bf-bf293fc34263"),
         imageUrl = "/lux/images/drechtsteden/resneighborhoods/oostdonk.png",
         pageComponent = { Oostdonk() }
     )
@@ -30,6 +32,7 @@ val kerkbuurt =
         label = LocalizedText(nl = "Energy Twin Kerkbuurt"),
         applicationArea = LuxApplicationArea.LUX_NEIGHBOURHOOD,
         entryPoint = "drechtsteden/resneighborhoods/kerkbuurt",
+        modelId = Uuid.parse("a8d6e6ae-8a4c-4685-9195-33b9cd986c48"),
         imageUrl = "/lux/images/drechtsteden/resneighborhoods/kerkbuurt.png",
         pageComponent = { Kerkbuurt() }
     )

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/drechtsteden/pages/resregion/resRegionModels.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/drechtsteden/pages/resregion/resRegionModels.kt
@@ -4,6 +4,7 @@ import energy.lux.frontend.core.services.localization.LocalizedText
 import energy.lux.frontend.domains.lux.sections.application_fields.DrechtstedenProjectArea
 import energy.lux.frontend.domains.lux.sections.application_fields.LuxApplicationArea
 import energy.lux.frontend.domains.lux.subdomains.private_subdomains.drechtsteden.DrechtstedenTwinModel
+import kotlin.uuid.Uuid
 
 
 val drechtstedenResRegion =
@@ -12,6 +13,7 @@ val drechtstedenResRegion =
         label = LocalizedText(nl = "Energy Twin Drechtsteden"),
         applicationArea = LuxApplicationArea.LUX_REGION,
         entryPoint = "drechtsteden/resregion/drechtsteden",
+        modelId = Uuid.parse("fc879bf3-c6ae-41f5-90f6-af2726e03da7"),
         imageUrl = "/lux/images/drechtsteden/res-region/drechtsteden.png",
         pageComponent = { DrechtstedenRegioIndex() }
     )

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/genius/Genius.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/genius/Genius.kt
@@ -23,6 +23,7 @@ fun Genius() {
     ) {
         PrivateTwinModelPage(
             entryPoint = PrivateSubdomainModel.GENUIS.entryPoint,
+            modelId = PrivateSubdomainModel.GENUIS.modelId,
             imageUrl = "/lux/images/models/genius.png",
             introContent = { GeniusIntroTextBlock() },
             mediaContent = {

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/oss/OssTwinModel.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/oss/OssTwinModel.kt
@@ -35,6 +35,7 @@ val elzenburgDeGeer =
         label = LocalizedText("Elzenburg-De Geer"),
         imageUrl = "/lux/images/oss/elzenburgDeGeer.jpeg",
         entryPoint = "oss/elzenburgDeGeer",
+        modelId = Uuid.parse("8ca125d4-cc2c-4cbe-896a-6b49dd87016b"),
         pageComponent = { ElzenburgDeGeer() },
     )
 val vorstenGrafDonk =
@@ -42,6 +43,7 @@ val vorstenGrafDonk =
         label = LocalizedText("Vorstengrafdonk"),
         imageUrl = "/lux/images/oss/vorstengrafdonk.jpeg",
         entryPoint = "oss/vorstengrafdonk",
+        modelId = Uuid.parse("1b64c592-79b3-48dc-a10d-7b41136c2d71"),
         pageComponent = { VorstenGrafDonk() },
     )
 val moleneind =
@@ -49,6 +51,7 @@ val moleneind =
         label = LocalizedText("Moleneind"),
         imageUrl = "/lux/images/oss/moleneind.jpeg",
         entryPoint = "oss/moleneind",
+        modelId = Uuid.parse("5a23c46b-089b-4095-9364-083d6411e574"),
         pageComponent = { Moleneind() },
     )
 

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/oss/pages/ElzenburgDeGeer.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/oss/pages/ElzenburgDeGeer.kt
@@ -13,6 +13,7 @@ fun ElzenburgDeGeer() {
     PrivateTwinModelPage(
         entryPoint = elzenburgDeGeer.entryPoint,
         imageUrl = elzenburgDeGeer.imageUrl,
+        modelId = elzenburgDeGeer.modelId,
         introContent = {
             HeaderText(
                 enText = elzenburgDeGeer.label.en,

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/oss/pages/Moleneind.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/oss/pages/Moleneind.kt
@@ -13,6 +13,7 @@ fun Moleneind() {
     PrivateTwinModelPage(
         entryPoint = moleneind.entryPoint,
         imageUrl = moleneind.imageUrl,
+        modelId = moleneind.modelId,
         introContent = {
             HeaderText(
                 enText = moleneind.label.en,

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/oss/pages/VorstenGrafDonk.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/oss/pages/VorstenGrafDonk.kt
@@ -13,6 +13,7 @@ fun VorstenGrafDonk() {
     PrivateTwinModelPage(
         entryPoint = vorstenGrafDonk.entryPoint,
         imageUrl = vorstenGrafDonk.imageUrl,
+        modelId = vorstenGrafDonk.modelId,
         introContent = {
             HeaderText(
                 enText = vorstenGrafDonk.label.en,

--- a/site/src/jsMain/kotlin/protected/ProtectedWrapper.kt
+++ b/site/src/jsMain/kotlin/protected/ProtectedWrapper.kt
@@ -13,25 +13,26 @@ import web.http.RequestCredentials
 import web.http.RequestInit
 import web.http.fetch
 
-external interface PrivateTextModule {
-    @Composable
-    fun ProtectedComponent()
+typealias ProtectedComponent<P> = @Composable (props: P) -> Unit
+
+external interface PrivateTextModule<P> {
+    val ProtectedComponent: ProtectedComponent<P>
 }
 
-sealed class AccessStatus {
-    data object Pending : AccessStatus()
-    data object NotLoggedIn : AccessStatus()
-    data object NotEnoughPrivileges : AccessStatus()
-    data class Error(val errorMessage: String) : AccessStatus()
-    data class Success(val protectedComponent: @Composable () -> Unit) : AccessStatus()
+sealed class AccessStatus<out P> {
+    data object Pending : AccessStatus<Nothing>()
+    data object NotLoggedIn : AccessStatus<Nothing>()
+    data object NotEnoughPrivileges : AccessStatus<Nothing>()
+    data class Error(val errorMessage: String) : AccessStatus<Nothing>()
+    data class Success<P>(val protectedComponent: ProtectedComponent<P>, val props: P) : AccessStatus<P>()
 }
 
-typealias ProtectedDisplayComponent = @Composable (
-    status: AccessStatus,
+typealias ProtectedDisplayComponent<P> = @Composable (
+    status: AccessStatus<P>
 ) -> Unit
 
 @Composable
-fun DefaultProtectedDisplay(status: AccessStatus) {
+fun <P> DefaultProtectedDisplay(status: AccessStatus<P>) {
     when (status) {
         AccessStatus.Pending -> Pending()
         AccessStatus.NotLoggedIn -> Login()
@@ -40,28 +41,32 @@ fun DefaultProtectedDisplay(status: AccessStatus) {
             ErrorWidget(errorMessage = status.errorMessage)
         }
         is AccessStatus.Success -> {
-            status.protectedComponent()
+            status.protectedComponent(status.props)
         }
     }
 }
 
 @Composable
-fun ProtectedWrapper(
+fun <P> ProtectedWrapper(
     entryPoint: String,
-    display: ProtectedDisplayComponent = { status -> DefaultProtectedDisplay(status) },
+    props: P,
+    display: ProtectedDisplayComponent<P> = { DefaultProtectedDisplay(it) }
 ) {
-    var status by remember { mutableStateOf<AccessStatus>(AccessStatus.Pending) }
+    var status by remember { mutableStateOf<AccessStatus<P>>(AccessStatus.Pending) }
 
     LaunchedEffect(Unit) {
         try {
             val entryPointParts = entryPoint.split("/")
             val privateModule =
                 when (entryPointParts.size) {
-                    2 -> importAsync<PrivateTextModule>("./entrypoints/${entryPointParts[0]}/${entryPointParts[1]}/ProtectedComponent.export.mjs").await()
-                    3 -> importAsync<PrivateTextModule>("./entrypoints/${entryPointParts[0]}/${entryPointParts[1]}/${entryPointParts[2]}/ProtectedComponent.export.mjs").await()
-                    else -> importAsync<PrivateTextModule>("./entrypoints/$entryPoint/ProtectedComponent.export.mjs").await()
+                    2 -> importAsync<PrivateTextModule<P>>("./entrypoints/${entryPointParts[0]}/${entryPointParts[1]}/ProtectedComponent.export.mjs").await()
+                    3 -> importAsync<PrivateTextModule<P>>("./entrypoints/${entryPointParts[0]}/${entryPointParts[1]}/${entryPointParts[2]}/ProtectedComponent.export.mjs").await()
+                    else -> importAsync<PrivateTextModule<P>>("./entrypoints/$entryPoint/ProtectedComponent.export.mjs").await()
                 }
-            status = AccessStatus.Success { privateModule.ProtectedComponent() }
+            status = AccessStatus.Success(
+                protectedComponent = privateModule.ProtectedComponent,
+                props = props
+            )
         } catch (e: Throwable) {
             /**
              * We get no status code after import failure.


### PR DESCRIPTION
Refactor: Make `ProtectedComponent` accept `modelId` as parameter

Changes:
- Add generic type parameter P to `AccessStatus`, `ProtectedWrapper`, and related types   
- `ModelWrapper` now accepts `modelId` as parameter and passes it through
- API keys remain embedded in private modules