### PR TITLE
Fix protected module import

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="FrameworkDetectionExcludesConfiguration">

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,6 +2,5 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/site/src/jsMain/kotlin/com/zenmo/web/zenmo/protected/entrypoints" vcs="Git" />
   </component>
 </project>

--- a/site/rollup/rollup.config.mjs
+++ b/site/rollup/rollup.config.mjs
@@ -2,7 +2,7 @@ import dynamicImportVars from '@rollup/plugin-dynamic-import-vars';
 import nodeResolve from "@rollup/plugin-node-resolve";
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
-import { globSync } from 'glob';
+import {globSync} from 'glob';
 import "core-js/stable/array/to-sorted.js"
 
 const rootProjectDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..")
@@ -42,6 +42,29 @@ export default {
             ],
         }),
         dynamicImportVars(),
+        {
+            name: 'dynamic-import-meta',
+            renderDynamicImport({ targetModuleId }) {
+                if (targetModuleId) {
+                    // Wrap the default import() with a try-catch which stores the module name.
+                    // This is used in ProtectedWrapper.kt to figure out the cause of the failure
+                    // and redirect the user to the login page if applicable.
+                    return {
+                        left: `
+                            (function(p) {
+                                return import(p)
+                                    .catch(e => {
+                                        e.resolvedModule = p;
+                                        throw e;
+                                    })
+                            })(
+                        `.trim(),
+                        right: ')'
+                    };
+                }
+                return null;
+            }
+        },
     ]
 }
 
@@ -61,7 +84,7 @@ function getFirstImporterWithAccessPolicy(moduleId, getModuleInfo) {
         moduleId => getModuleInfo(moduleId).exports.includes("accessPolicy")
     )
 
-    if (!importersWithAccessPolicy.length === 0) {
+    if (importersWithAccessPolicy.length === 0) {
         throw Error(`accessPolicy not found in importers of ${moduleId}`)
     }
 

--- a/site/src/jsMain/kotlin/protected/ProtectedWrapper.kt
+++ b/site/src/jsMain/kotlin/protected/ProtectedWrapper.kt
@@ -68,16 +68,16 @@ fun <P> ProtectedWrapper(
                 props = props
             )
         } catch (e: Throwable) {
+            val resolvedModule = getModuleNameFromException(e)
             /**
              * We get no status code after import failure.
              * To determine the status code, we do the same request again using AJAX.
              */
-            val fileName = e.message?.substringAfterLast('/')
-            if (fileName == null) {
+            if (resolvedModule == null) {
                 status = AccessStatus.Error(
                     LanguageManager.language.value.translate(
-                        en = "Failed to load module.",
-                        nl = "Kon de module niet laden."
+                        en = "Error when doing dynamic import of module. Details: ${e.message}",
+                        nl = "Fout bij dynamische import van de module. Details: ${e.message}"
                     )
                 )
                 return@LaunchedEffect
@@ -85,7 +85,7 @@ fun <P> ProtectedWrapper(
 
             try {
                 val response = fetch(
-                    AppGlobals.getValue("BACKEND_URL") + "/" + fileName, RequestInit(
+                    AppGlobals.getValue("BACKEND_URL") + "/" + resolvedModule, RequestInit(
                         credentials = RequestCredentials.include
                     )
                 )
@@ -94,9 +94,9 @@ fun <P> ProtectedWrapper(
                     403 -> AccessStatus.NotEnoughPrivileges
                     else -> AccessStatus.Error(
                         LanguageManager.language.value.translate(
-                            en = "An error occurred while accessing module.",
-                            nl = "Er is een fout opgetreden bij het openen van de module."
-                        )
+                            en = "An error occurred while doing dynamic import of $resolvedModule.",
+                            nl = "Er is een fout opgetreden bij de dynamic import $resolvedModule."
+                        ) + " HTTP status ${response.status}. Import message: ${e.message}"
                     )
                 }
             } catch (e: Throwable) {
@@ -116,4 +116,19 @@ fun <P> ProtectedWrapper(
     ) {
         display(status)
     }
+}
+
+fun getModuleNameFromException(e: Throwable): String? {
+    /**
+     * `resolvedModule` is the module name after bundling.
+     * It is set through rollup.config.mjs
+     */
+    var resolvedModule: String? = e.asDynamic().resolvedModule
+    if (resolvedModule == null && e.message != null) {
+        // Fallback to get the module name from the error message.
+        // Does not work in Safari.
+        val regex = Regex("[^/]*\\.mjs")
+        resolvedModule = regex.find(e.message ?: "")?.value
+    }
+    return resolvedModule
 }


### PR DESCRIPTION
In Safari the user was not redirected to the login page. The cause is that the module name is not the error message so we could not figure out the response code (401).

The solution is to add the module name to the error through a custom Rollup plugin.

Closes #587