### PR TITLE
refactor `LanguageToggleButton` for lux and zenmo domains

### DIFF
--- a/site/src/jsMain/kotlin/components/widgets/navbar_actions/LanguageOptionButton.kt
+++ b/site/src/jsMain/kotlin/components/widgets/navbar_actions/LanguageOptionButton.kt
@@ -1,0 +1,54 @@
+package energy.lux.frontend.components.widgets.navbar_actions
+
+import androidx.compose.runtime.Composable
+import com.varabyte.kobweb.compose.css.Cursor
+import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.graphics.Colors
+import com.varabyte.kobweb.compose.ui.modifiers.*
+import com.varabyte.kobweb.compose.ui.thenIf
+import com.varabyte.kobweb.compose.ui.toAttrs
+import com.varabyte.kobweb.silk.style.CssStyle
+import com.varabyte.kobweb.silk.style.toModifier
+import com.zenmo.web.zenmo.theme.font.HeaderTextStyle
+import com.zenmo.web.zenmo.theme.font.TextStyle
+import energy.lux.frontend.domains.lux.styles.verticalLinearBackground
+import org.jetbrains.compose.web.attributes.ButtonType
+import org.jetbrains.compose.web.css.cssRem
+import org.jetbrains.compose.web.dom.Div
+import org.jetbrains.compose.web.dom.Text
+
+val LanguageOptionButtonStyle = CssStyle(
+    extraModifier = { TextStyle.toModifier(HeaderTextStyle) }
+) {
+    base {
+        Modifier
+            .fontSize(1.cssRem)
+            .padding(0.5.cssRem)
+            .cursor(Cursor.Pointer)
+    }
+}
+
+
+@Composable
+fun LanguageOptionButton(
+    label: String,
+    onSelect: () -> Unit,
+    isSelected: Boolean,
+    modifier: Modifier = LanguageOptionButtonStyle.toModifier(),
+    selectedModifier: Modifier = Modifier.verticalLinearBackground()
+        .color(Colors.White)
+) {
+    Div(
+        modifier
+            .thenIf(isSelected, selectedModifier)
+            .role(ButtonType.Button.str)
+            .cursor(Cursor.Pointer)
+            .onClick {
+                onSelect()
+                it.stopPropagation()
+            }
+            .toAttrs()
+    ) {
+        Text(label)
+    }
+}

--- a/site/src/jsMain/kotlin/components/widgets/navbar_actions/LanguageToggleButton.kt
+++ b/site/src/jsMain/kotlin/components/widgets/navbar_actions/LanguageToggleButton.kt
@@ -1,31 +1,20 @@
-package energy.lux.frontend.domains.zenmo.sections.nav_header.components
+package energy.lux.frontend.components.widgets.navbar_actions
 
 import androidx.compose.runtime.Composable
-import com.varabyte.kobweb.compose.css.Cursor
 import com.varabyte.kobweb.compose.css.Overflow
 import com.varabyte.kobweb.compose.foundation.layout.Row
 import com.varabyte.kobweb.compose.ui.Modifier
-import com.varabyte.kobweb.compose.ui.graphics.Colors
 import com.varabyte.kobweb.compose.ui.modifiers.*
 import com.varabyte.kobweb.compose.ui.thenIf
-import com.varabyte.kobweb.compose.ui.toAttrs
-import com.varabyte.kobweb.silk.style.toModifier
-import com.zenmo.web.zenmo.theme.font.HeaderTextStyle
-import com.zenmo.web.zenmo.theme.font.TextStyle
 import energy.lux.frontend.core.services.localization.Language
 import energy.lux.frontend.core.services.localization.LanguageChangeHandler
 import energy.lux.frontend.core.services.localization.LocalLanguage
 import energy.lux.frontend.core.services.localization.rememberLanguageChangeHandler
-import energy.lux.frontend.domains.lux.styles.verticalLinearBackground
 import energy.lux.frontend.theme.SitePalette
 import energy.lux.frontend.theme.isZenmoDomain
 import energy.lux.frontend.theme.styles.luxBorderRadius
-import org.jetbrains.compose.web.attributes.ButtonType
 import org.jetbrains.compose.web.css.LineStyle
-import org.jetbrains.compose.web.css.cssRem
 import org.jetbrains.compose.web.css.px
-import org.jetbrains.compose.web.dom.Div
-import org.jetbrains.compose.web.dom.Text
 
 
 @Composable
@@ -57,32 +46,5 @@ fun LanguageToggleButton(
             onSelect = { languageHandler.setLanguage(Language.Dutch) },
             isSelected = language == Language.Dutch,
         )
-    }
-}
-
-@Composable
-private fun LanguageOptionButton(
-    label: String,
-    onSelect: () -> Unit,
-    isSelected: Boolean,
-) {
-    Div(
-        TextStyle.toModifier(HeaderTextStyle)
-            .fontSize(1.cssRem)
-            .role(ButtonType.Button.str)
-            .padding(0.5.cssRem)
-            .thenIf(
-                isSelected,
-                Modifier.verticalLinearBackground()
-                    .color(Colors.White)
-            )
-            .cursor(Cursor.Pointer)
-            .onClick {
-                onSelect()
-                it.stopPropagation()
-            }
-            .toAttrs()
-    ) {
-        Text(label)
     }
 }

--- a/site/src/jsMain/kotlin/components/widgets/navbar_actions/SiteLanguageButton.kt
+++ b/site/src/jsMain/kotlin/components/widgets/navbar_actions/SiteLanguageButton.kt
@@ -6,7 +6,6 @@ import com.varabyte.kobweb.compose.ui.Modifier
 import com.varabyte.kobweb.compose.ui.modifiers.scale
 import energy.lux.frontend.core.services.localization.LocalizedText
 import energy.lux.frontend.core.services.localization.rememberLanguageChangeHandler
-import energy.lux.frontend.domains.zenmo.sections.nav_header.components.LanguageToggleButton
 
 @Composable
 fun SiteLanguageButton() {

--- a/site/src/jsMain/kotlin/domains/zenmo/sections/nav_header/NavHeader.kt
+++ b/site/src/jsMain/kotlin/domains/zenmo/sections/nav_header/NavHeader.kt
@@ -23,7 +23,6 @@ import com.varabyte.kobweb.silk.theme.colors.palette.background
 import com.varabyte.kobweb.silk.theme.colors.palette.overlay
 import com.varabyte.kobweb.silk.theme.colors.palette.toPalette
 import energy.lux.frontend.components.SideMenuState
-import energy.lux.frontend.domains.zenmo.sections.nav_header.components.LanguageToggleButton
 import energy.lux.frontend.domains.zenmo.sections.nav_header.components.NavBar
 import energy.lux.frontend.domains.zenmo.sections.nav_header.components.SideMenu
 import energy.lux.frontend.domains.zenmo.sections.nav_header.components.SiteLogo
@@ -90,7 +89,7 @@ fun NavHeader() {
             ) {
                 NavBar()
             }
-            LanguageToggleButton()
+            ZenmoLanguageToggleButton()
         }
 
 
@@ -103,17 +102,9 @@ fun NavHeader() {
         ) {
             var menuState by remember { mutableStateOf(SideMenuState.CLOSED) }
 
-            Box(modifier = Modifier.flex(1), contentAlignment = Alignment.CenterStart) {
-                LanguageToggleButton()
-            }
-
-            Box(modifier = Modifier.flex(1), contentAlignment = Alignment.Center) {
-                SiteLogo()
-            }
-
-            Box(modifier = Modifier.flex(1), contentAlignment = Alignment.CenterEnd) {
-                HamburgerButton(onClick = { menuState = SideMenuState.OPEN })
-            }
+            ZenmoLanguageToggleButton()
+            SiteLogo()
+            HamburgerButton(onClick = { menuState = SideMenuState.OPEN })
 
             if (menuState != SideMenuState.CLOSED) {
                 SideMenu(

--- a/site/src/jsMain/kotlin/domains/zenmo/sections/nav_header/ZenmoLanguageToggleButton.kt
+++ b/site/src/jsMain/kotlin/domains/zenmo/sections/nav_header/ZenmoLanguageToggleButton.kt
@@ -1,0 +1,74 @@
+package energy.lux.frontend.domains.zenmo.sections.nav_header
+
+import androidx.compose.runtime.Composable
+import com.varabyte.kobweb.compose.css.FontWeight
+import com.varabyte.kobweb.compose.css.Transition
+import com.varabyte.kobweb.compose.foundation.layout.Arrangement
+import com.varabyte.kobweb.compose.foundation.layout.Row
+import com.varabyte.kobweb.compose.ui.Alignment
+import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.graphics.Colors
+import com.varabyte.kobweb.compose.ui.modifiers.*
+import com.varabyte.kobweb.silk.style.CssStyle
+import com.varabyte.kobweb.silk.style.base
+import com.varabyte.kobweb.silk.style.toModifier
+import com.zenmo.web.zenmo.theme.font.LabelTextStyle
+import com.zenmo.web.zenmo.theme.font.TextStyle
+import energy.lux.frontend.components.widgets.navbar_actions.LanguageOptionButton
+import energy.lux.frontend.core.services.localization.Language
+import energy.lux.frontend.core.services.localization.LocalLanguage
+import energy.lux.frontend.core.services.localization.rememberLanguageChangeHandler
+import energy.lux.frontend.theme.SitePalette
+import org.jetbrains.compose.web.css.*
+
+val ZenmoLanguageToggleButtonStyle = CssStyle(
+    extraModifier = { TextStyle.toModifier(LabelTextStyle) }
+) {
+    base {
+        Modifier
+            .borderRadius(30.px)
+            .border(1.px, LineStyle.Solid, Colors.LightGrey)
+            .padding(0.35.cssRem, 0.85.cssRem)
+            .transition(
+                Transition.of(
+                    property = "all",
+                    duration = 300.ms,
+                    timingFunction = AnimationTimingFunction.Ease
+                )
+            )
+    }
+}
+
+val ActiveLanguageOptionStyle = CssStyle.base {
+    Modifier
+        .backgroundColor(Colors.Transparent)
+        .color(SitePalette.light.primary)
+        .fontWeight(FontWeight.Bold)
+        .border(2.px, LineStyle.Solid, SitePalette.light.primary)
+}
+
+@Composable
+fun ZenmoLanguageToggleButton() {
+    Row(
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.gap(0.5.cssRem)
+    ) {
+        val languageHandler = rememberLanguageChangeHandler()
+        val language = LocalLanguage.current
+        LanguageOptionButton(
+            label = "EN",
+            onSelect = { languageHandler.setLanguage(Language.English) },
+            isSelected = language == Language.English,
+            modifier = ZenmoLanguageToggleButtonStyle.toModifier(),
+            selectedModifier = ActiveLanguageOptionStyle.toModifier()
+        )
+        LanguageOptionButton(
+            label = "NL",
+            onSelect = { languageHandler.setLanguage(Language.Dutch) },
+            isSelected = language == Language.Dutch,
+            modifier = ZenmoLanguageToggleButtonStyle.toModifier(),
+            selectedModifier = ActiveLanguageOptionStyle.toModifier()
+        )
+    }
+}


### PR DESCRIPTION
part of implementing the nav bar in the mockup for the zenmo website  https://www.figma.com/design/ehnC378P2e72ukBFtVJr87/zenmo-website?node-id=0-1&t=1AIdyinZJ0OKPrvN-1 