### PR TITLE
introduce fluid spatial dimensions via css clamp for responsive padding and gap calculations

### DIFF
--- a/site/src/commonTest/kotlin/SiteFluidSpacingTest.kt
+++ b/site/src/commonTest/kotlin/SiteFluidSpacingTest.kt
@@ -1,0 +1,118 @@
+package energy.lux.frontend
+
+import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.modifiers.gap
+import com.varabyte.kobweb.compose.ui.modifiers.padding
+import com.varabyte.kobweb.compose.ui.toAttrs
+import energy.lux.frontend.theme.SiteFluidSpacing
+import energy.lux.frontend.theme.computeFluidClamp
+import kotlinx.browser.window
+import org.jetbrains.compose.web.css.px
+import org.jetbrains.compose.web.dom.Div
+import org.jetbrains.compose.web.testutils.ComposeWebExperimentalTestsApi
+import org.jetbrains.compose.web.testutils.runTest
+import org.w3c.dom.Element
+import kotlin.math.max
+import kotlin.math.min
+import kotlin.test.Ignore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ComposeWebExperimentalTestsApi::class)
+class SiteFluidSpacingTest {
+
+    private val spacing = SiteFluidSpacing(
+        minHorizontalPadding = 15.px,
+        maxHorizontalPadding = 250.px,
+        minVerticalPadding = 50.px,
+        maxVerticalPadding = 120.px,
+        minGap = 8.px,
+        maxGap = 32.px,
+    )
+
+    // window.resizeTo() is a no-op in the karma headless environment — the viewport stays
+    // fixed (~765px) so this test always runs at the wrong size. Needs Playwright to fix.
+    @Ignore
+    @Test
+    fun `horizontal padding at narrow viewport`() = runTest {
+        window.resizeTo(400, 768)
+        composition {
+            Div(attrs = Modifier.padding(leftRight = spacing.horizontalPadding).toAttrs()) {}
+        }
+        assertEquals(
+            expected = 15.0,
+            actual = computedPxProperty("padding-left", root.firstElementChild!!),
+            absoluteTolerance = 1.0,
+        )
+    }
+
+    @Test
+    fun `horizontal padding at mid viewport`() = runTest {
+        window.resizeTo(890, 768)
+        composition {
+            Div(attrs = Modifier.padding(leftRight = spacing.horizontalPadding).toAttrs()) {}
+        }
+        assertEquals(
+            expected = expectedClamp(minPx = 15.0, maxPx = 250.0),
+            actual = computedPxProperty("padding-left", root.firstElementChild!!),
+            absoluteTolerance = 1.0,
+        )
+    }
+
+    @Ignore
+    @Test
+    fun `horizontal padding at wide viewport`() = runTest {
+        window.resizeTo(1400, 768)
+        composition {
+            Div(attrs = Modifier.padding(leftRight = spacing.horizontalPadding).toAttrs()) {}
+        }
+        assertEquals(
+            expected = 250.0,
+            actual = computedPxProperty("padding-left", root.firstElementChild!!),
+            absoluteTolerance = 1.0,
+        )
+    }
+
+    @Test
+    fun `vertical padding at mid viewport`() = runTest {
+        window.resizeTo(890, 768)
+        composition {
+            Div(attrs = Modifier.padding(topBottom = spacing.verticalPadding).toAttrs()) {}
+        }
+        assertEquals(
+            expected = expectedClamp(minPx = 50.0, maxPx = 120.0),
+            actual = computedPxProperty("padding-top", root.firstElementChild!!),
+            absoluteTolerance = 1.0,
+        )
+    }
+
+    @Test
+    fun `gap at mid viewport`() = runTest {
+        window.resizeTo(890, 768)
+        composition {
+            Div(attrs = Modifier.gap(spacing.gap).toAttrs {
+                style { property("display", "flex") }
+            }) {}
+        }
+        assertEquals(
+            expected = expectedClamp(minPx = 8.0, maxPx = 32.0),
+            actual = computedPxProperty("column-gap", root.firstElementChild!!),
+            absoluteTolerance = 1.0,
+        )
+    }
+
+    private fun computedPxProperty(property: String, element: Element): Double =
+        window.getComputedStyle(element)
+            .getPropertyValue(property)
+            .removeSuffix("px")
+            .toDouble()
+
+    // Evaluates the CSS clamp formula in Kotlin so we have a number to assert against.
+    // Both sides use the same math — the test verifies the browser applies the expression,
+    // not that the formula is correct.
+    private fun expectedClamp(minPx: Double, maxPx: Double): Double {
+        val params = computeFluidClamp(minPx, maxPx)
+        val viewportPx = window.innerWidth.toDouble()
+        return max(minPx, min(maxPx, params.intersectionPx + params.slopeVwPercent / 100.0 * viewportPx))
+    }
+}

--- a/site/src/jsMain/kotlin/theme/SiteFluidSpacing.kt
+++ b/site/src/jsMain/kotlin/theme/SiteFluidSpacing.kt
@@ -1,0 +1,107 @@
+package energy.lux.frontend.theme
+
+import com.varabyte.kobweb.compose.css.functions.calc
+import com.varabyte.kobweb.compose.css.functions.clamp
+import energy.lux.frontend.pages.SiteGlobals
+import kotlinx.browser.document
+import kotlinx.browser.window
+import org.jetbrains.compose.web.css.*
+
+
+internal data class FluidClampParams(
+    val minPx: Double,
+    val intersectionPx: Double,
+    val slopeVwPercent: Double,
+    val maxPx: Double
+)
+
+/**
+ * Turns min/max px values into `clamp()` params via linear
+ * interpolation across the viewport range.
+ * */
+internal fun computeFluidClamp(
+    minPx: Double,
+    maxPx: Double,
+    minViewportPx: Double = 480.0,
+    maxViewportPx: Double = 1300.0
+): FluidClampParams {
+    val slope = (maxPx - minPx) / (maxViewportPx - minViewportPx)
+    return FluidClampParams(minPx, minPx - slope * minViewportPx, slope * 100.0, maxPx)
+}
+
+private fun CSSUnitValue.toPx(): Double {
+    val n = value.toDouble()
+    val s = toString().trim()
+    return if (s.endsWith("rem") || s.endsWith("em")) n * rootRemInPx() else n // else: already px
+}
+
+/**
+ * Spacing that scales fluidly between viewport breakpoints via CSS `clamp()`.
+ * One config per subdomain — see [current].
+ */
+data class SiteFluidSpacing(
+    private val minHorizontalPadding: CSSUnitValue,
+    private val maxHorizontalPadding: CSSUnitValue,
+    private val minVerticalPadding: CSSUnitValue,
+    private val maxVerticalPadding: CSSUnitValue,
+    private val minGap: CSSUnitValue = 1.cssRem,
+    private val maxGap: CSSUnitValue = 3.cssRem,
+) {
+    val horizontalPadding: CSSNumericValue<out CSSUnitLengthOrPercentage>
+        get() = calculateFluidClamp(
+            minHorizontalPadding,
+            maxHorizontalPadding
+        )
+
+    val verticalPadding: CSSNumericValue<out CSSUnitLengthOrPercentage>
+        get() = calculateFluidClamp(
+            minVerticalPadding,
+            maxVerticalPadding
+        )
+
+    val gap: CSSNumericValue<out CSSUnitLengthOrPercentage>
+        get() = calculateFluidClamp(minGap, maxGap)
+
+
+    // unsafeCast needed: clamp() returns CSSStyleValue but Kobweb's modifiers want CSSNumericValue
+    private fun calculateFluidClamp(
+        min: CSSUnitValue,
+        max: CSSUnitValue,
+    ): CSSNumericValue<out CSSUnitLengthOrPercentage> {
+        val params = computeFluidClamp(min.toPx(), max.toPx())
+        return clamp(
+            min,
+            calc { num(params.intersectionPx).px + num(params.slopeVwPercent).vw },
+            max,
+        ).unsafeCast<CSSNumericValue<out CSSUnitLengthOrPercentage>>()
+    }
+
+    companion object {
+        private val luxFluidDimensions = SiteFluidSpacing(
+            minHorizontalPadding = 15.px,
+            maxHorizontalPadding = 250.px,
+            minVerticalPadding = 50.px,
+            maxVerticalPadding = 120.px,
+            minGap = 2.cssRem,
+            maxGap = 4.cssRem,
+        )
+        private val zenmoFluidDimensions = SiteFluidSpacing(
+            minHorizontalPadding = 16.px,
+            maxHorizontalPadding = 134.px,
+            minVerticalPadding = 40.px,
+            maxVerticalPadding = 100.px,
+        )
+
+        val current: SiteFluidSpacing
+            get() = when (window.location.host) {
+                SiteGlobals.ZENMO_DOMAIN -> zenmoFluidDimensions
+                else -> luxFluidDimensions
+            }
+    }
+}
+
+fun rootRemInPx(): Double =
+    window.getComputedStyle(document.documentElement!!)
+        .getPropertyValue("font-size")
+        .removeSuffix("px")
+        .toDouble()


### PR DESCRIPTION
Our layout containers (`SectionContainerStyle` and its variants) currently rely on verbose breakpoint blocks (ZERO through XL) to adjust padding and gaps.

This PR introduces `SiteFluidSpacing`, a centralized configuration that automatically handles responsive spacing. By using `CSS clamp()` and `calc()` under the hood, it replaces rigid media queries with fluid scaling between our 480px and 1300px viewports.