### PR TITLE
lazy-load @zenmo/oss-gis-map to reduce main bundle size

### DIFF
--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/oss/OssGisMap.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/oss/OssGisMap.kt
@@ -6,13 +6,12 @@ import com.varabyte.kobweb.compose.foundation.layout.Box
 import com.varabyte.kobweb.compose.ui.Modifier
 import com.varabyte.kobweb.compose.ui.modifiers.height
 import com.varabyte.kobweb.compose.ui.modifiers.width
-import energy.lux.frontend.domains.lux.subdomains.private_subdomains.oss.OssGisMapModule.showOssMap
+import js.import.importAsync
 import org.jetbrains.compose.web.css.percent
 import org.jetbrains.compose.web.css.px
 import org.w3c.dom.HTMLElement
 
-@JsModule("@zenmo/oss-gis-map")
-external object OssGisMapModule {
+private external interface OssGisMapEntryModule {
     fun showOssMap(element: HTMLElement)
 }
 
@@ -22,6 +21,9 @@ fun OssGisMap() {
         modifier = Modifier
             .height(500.px)
             .width(100.percent),
-        ref = ref { showOssMap(it) }
+        ref = ref { el ->
+            importAsync<OssGisMapEntryModule>("./gismap/OssGisMapEntry.export.mjs")
+                .then { module -> module.showOssMap(el) }
+        }
     )
 }

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/oss/gismap/OssGisMapEntry.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/oss/gismap/OssGisMapEntry.kt
@@ -1,0 +1,15 @@
+package energy.lux.frontend.domains.lux.subdomains.private_subdomains.oss.gismap
+
+import energy.lux.site.shared.AccessPolicy
+import org.w3c.dom.HTMLElement
+
+@JsModule("@zenmo/oss-gis-map")
+private external object OssGisMapJs {
+    fun showOssMap(element: HTMLElement)
+}
+
+@JsExport
+val accessPolicy = AccessPolicy.Public()
+
+@JsExport
+fun showOssMap(element: HTMLElement) = OssGisMapJs.showOssMap(element)


### PR DESCRIPTION
moves `@zenmo/oss-gis-map` (and its `@maptiler/sdk` dependencies) into a separate lazy chunk by splitting `OssGisMap.kt` into an entry file with a dynamic import. reduces the main bundle by ~1.7MB