### PR TITLE
lazy-load domain bundles via dynamic import

### DIFF
--- a/site/src/jsMain/kotlin/pages/DomainRoutes.kt
+++ b/site/src/jsMain/kotlin/pages/DomainRoutes.kt
@@ -4,11 +4,9 @@ import androidx.compose.runtime.Composable
 import com.varabyte.kobweb.core.AppGlobals
 import com.varabyte.kobweb.core.Page
 import energy.lux.frontend.components.widgets.UnknownDomain
-import energy.lux.frontend.domains.lux.core.model.subdomain.subdomains
-import energy.lux.frontend.domains.lux.pages.LuxRoutingComponent
-import energy.lux.frontend.domains.lux.subdomains.LuxSubdomainRoutingComponent
-import energy.lux.frontend.domains.zenmo.pages.ZenmoRoutingComponent
+import energy.lux.frontend.protected.LazyModule
 import energy.lux.frontend.utils.setDomainFavicon
+import js.import.importAsync
 import kotlinx.browser.window
 
 object SiteGlobals {
@@ -23,15 +21,11 @@ fun DomainRoutes() {
     val luxSubdomainSuffix = ".${SiteGlobals.LUX_DOMAIN}"
 
     when {
-        domain == SiteGlobals.LUX_DOMAIN -> LuxRoutingComponent()
-        domain == SiteGlobals.ZENMO_DOMAIN -> ZenmoRoutingComponent()
+        domain == SiteGlobals.LUX_DOMAIN -> LuxDomainLoader()
+        domain == SiteGlobals.ZENMO_DOMAIN -> ZenmoDomainLoader()
         domain.endsWith(luxSubdomainSuffix) -> {
             val sub = domain.substringBefore(luxSubdomainSuffix)
-
-            subdomains
-                .find { it.subdomain.equals(sub, ignoreCase = true) }
-                ?.let { LuxSubdomainRoutingComponent(it.subdomain) }
-                ?: UnknownDomain(sub)
+            LuxSubdomainLoader(sub)
         }
 
         else -> UnknownDomain(domain)
@@ -39,6 +33,38 @@ fun DomainRoutes() {
     setDomainFavicon()
 }
 
-
 fun isLocalOrPreviewEnvironment() =
     listOf("preview", "local").any { it in window.location.host }
+
+private external interface LuxDomainModule {
+    @Composable
+    fun LuxDomain()
+}
+
+private external interface ZenmoDomainModule {
+    @Composable
+    fun ZenmoDomain()
+}
+
+private external interface LuxSubdomainModule {
+    @Composable
+    fun LuxSubdomain(subdomain: String)
+}
+
+@Composable
+private fun LuxDomainLoader() = LazyModule(
+    load = { importAsync<LuxDomainModule>("./domains/lux/LuxDomainEntry.export.mjs") },
+    content = { LuxDomain() },
+)
+
+@Composable
+private fun ZenmoDomainLoader() = LazyModule(
+    load = { importAsync<ZenmoDomainModule>("./domains/zenmo/ZenmoDomainEntry.export.mjs") },
+    content = { ZenmoDomain() },
+)
+
+@Composable
+private fun LuxSubdomainLoader(subdomain: String) = LazyModule(
+    load = { importAsync<LuxSubdomainModule>("./domains/subdomains/LuxSubdomainEntry.export.mjs") },
+    content = { LuxSubdomain(subdomain) },
+)

--- a/site/src/jsMain/kotlin/pages/domains/lux/LuxDomainEntry.kt
+++ b/site/src/jsMain/kotlin/pages/domains/lux/LuxDomainEntry.kt
@@ -1,0 +1,14 @@
+package energy.lux.frontend.pages.domains.lux
+
+import androidx.compose.runtime.Composable
+import energy.lux.frontend.domains.lux.pages.LuxRoutingComponent
+import energy.lux.site.shared.AccessPolicy
+
+@JsExport
+val accessPolicy = AccessPolicy.Public()
+
+@JsExport
+@Composable
+fun LuxDomain() {
+    LuxRoutingComponent()
+}

--- a/site/src/jsMain/kotlin/pages/domains/subdomains/LuxSubdomainEntry.kt
+++ b/site/src/jsMain/kotlin/pages/domains/subdomains/LuxSubdomainEntry.kt
@@ -1,0 +1,14 @@
+package energy.lux.frontend.pages.domains.subdomains
+
+import androidx.compose.runtime.Composable
+import energy.lux.frontend.domains.lux.subdomains.LuxSubdomainRoutingComponent
+import energy.lux.site.shared.AccessPolicy
+
+@JsExport
+val accessPolicy = AccessPolicy.Public()
+
+@JsExport
+@Composable
+fun LuxSubdomain(subdomain: String) {
+    LuxSubdomainRoutingComponent(subdomain)
+}

--- a/site/src/jsMain/kotlin/pages/domains/zenmo/ZenmoDomainEntry.kt
+++ b/site/src/jsMain/kotlin/pages/domains/zenmo/ZenmoDomainEntry.kt
@@ -1,0 +1,14 @@
+package energy.lux.frontend.pages.domains.zenmo
+
+import androidx.compose.runtime.Composable
+import energy.lux.frontend.domains.zenmo.pages.ZenmoRoutingComponent
+import energy.lux.site.shared.AccessPolicy
+
+@JsExport
+val accessPolicy = AccessPolicy.Public()
+
+@JsExport
+@Composable
+fun ZenmoDomain() {
+    ZenmoRoutingComponent()
+}

--- a/site/src/jsMain/kotlin/protected/LazyModule.kt
+++ b/site/src/jsMain/kotlin/protected/LazyModule.kt
@@ -1,0 +1,22 @@
+package energy.lux.frontend.protected
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import js.promise.Promise
+
+@Composable
+fun <T : Any> LazyModule(
+    load: () -> Promise<T>,
+    content: @Composable T.() -> Unit,
+) {
+    var module by remember { mutableStateOf<T?>(null) }
+    LaunchedEffect(Unit) {
+        load().then { m -> module = m }
+    }
+    if (module == null) { Pending(); return }
+    module!!.content()
+}


### PR DESCRIPTION
splits `lux.energy`, `zenmo.com`, and `*.lux.energy` into separately lazy chunks

what improves:                                                                                                                                                                                                                   
  - zenmo.com visitors no longer download lux.energy pages                                                                                                                                      
  - lux.energy visitors no longer download zenmo.com pages                                                                                                                                 
  - *.lux.energy subdomains load neither
