### PR TITLE
ConstrainedWidthStyle utility for responsive content width

### DIFF
--- a/site/src/jsMain/kotlin/domains/zenmo/pages/models/ConstrainedWidthStyle.kt
+++ b/site/src/jsMain/kotlin/domains/zenmo/pages/models/ConstrainedWidthStyle.kt
@@ -1,0 +1,27 @@
+package energy.lux.frontend.domains.zenmo.pages.models
+
+import androidx.compose.runtime.Composable
+import com.varabyte.kobweb.compose.css.CSSLengthOrPercentageNumericValue
+import com.varabyte.kobweb.compose.css.StyleVariable
+import com.varabyte.kobweb.compose.ui.Modifier
+import com.varabyte.kobweb.compose.ui.modifiers.fillMaxWidth
+import com.varabyte.kobweb.compose.ui.modifiers.setVariable
+import com.varabyte.kobweb.compose.ui.modifiers.width
+import com.varabyte.kobweb.silk.style.CssStyle
+import com.varabyte.kobweb.silk.style.breakpoint.Breakpoint
+import com.varabyte.kobweb.silk.style.toModifier
+import org.jetbrains.compose.web.css.percent
+
+private val LgWidthVar by StyleVariable<CSSLengthOrPercentageNumericValue>()
+
+val ConstrainedWidthStyle = CssStyle {
+    base { Modifier.fillMaxWidth() }
+    Breakpoint.LG { Modifier.width(LgWidthVar.value()) }
+}
+
+@Composable
+fun Modifier.constrainedWidth(
+    lg: CSSLengthOrPercentageNumericValue = 80.percent,
+) = this
+    .setVariable(LgWidthVar, lg)
+    .then(ConstrainedWidthStyle.toModifier())


### PR DESCRIPTION
*Why*

Some page sections (description paragraphs of sections, headers, grid containers, ...) look better when they don't span the full page width on large screens and on small screens, i don't want to go narrower than full-width, so base should stay at fillMaxWidth


- adds `ConstrainedWidthStyle`  a reusable CssStyle that renders content at full width on small screens and 80% width on LG+ breakpoints
- exposes a `Modifier.constrainedWidth(lg)` extension so callers can override the large-screen width via a StyleVariable

