### PR TITLE
ci: make subdomain separator configurable

### DIFF
--- a/site/build.gradle.kts
+++ b/site/build.gradle.kts
@@ -19,8 +19,11 @@ plugins {
 group = "energy.lux.frontend"
 version = "1.0.0"
 
-val LUX_DOMAIN = System.getenv("LUX_DOMAIN") ?: "http://lux.localhost:8080"
-val ZENMO_DOMAIN = System.getenv("ZENMO_DOMAIN") ?: "http://zenmo.localhost:8080"
+val LUX_DOMAIN = System.getenv("LUX_DOMAIN") ?: "lux.localhost:8080"
+val ZENMO_DOMAIN = System.getenv("ZENMO_DOMAIN") ?: "zenmo.localhost:8080"
+/** @see [SiteGlobals.SUBDOMAIN_SEPARATOR] */
+val SUBDOMAIN_SEPARATOR = System.getenv("SUBDOMAIN_SEPARATOR") ?: "."
+
 val BACKEND_URL = System.getenv("BACKEND_URL") ?: "http://localhost:9000"
 val jsSrc = "$BACKEND_URL/main.export.mjs"
 
@@ -40,6 +43,7 @@ kobweb {
                 "BACKEND_URL" to BACKEND_URL,
                 "LUX_DOMAIN" to LUX_DOMAIN,
                 "ZENMO_DOMAIN" to ZENMO_DOMAIN,
+                "SUBDOMAIN_SEPARATOR" to SUBDOMAIN_SEPARATOR,
             )
         )
     }

--- a/site/src/jsMain/kotlin/components/layouts/PageLayout.kt
+++ b/site/src/jsMain/kotlin/components/layouts/PageLayout.kt
@@ -57,7 +57,7 @@ private fun documentTitleByDomain(extraTitle: String): String {
     return when {
         domain == SiteGlobals.ZENMO_DOMAIN -> "${previewText}Zenmo - $extraTitle"
         domain == SiteGlobals.LUX_DOMAIN -> "${previewText}LUX Energy"
-        domain.endsWith(".${SiteGlobals.LUX_DOMAIN}") -> "$extraTitle | LUX Energy"
+        domain.endsWith(SiteGlobals.luxSubdomainSuffix) -> "$extraTitle | LUX Energy"
         else -> "Unknown"
     }
 }

--- a/site/src/jsMain/kotlin/core/MenuFactory.kt
+++ b/site/src/jsMain/kotlin/core/MenuFactory.kt
@@ -21,8 +21,8 @@ object MenuFactory {
             domain == SiteGlobals.LUX_DOMAIN -> luxNavMenu
             domain == SiteGlobals.ZENMO_DOMAIN -> zenmoNavMenu
 
-            domain.endsWith(".${SiteGlobals.LUX_DOMAIN}") -> {
-                val subdomain = domain.substringBefore(".${SiteGlobals.LUX_DOMAIN}")
+            domain.endsWith(SiteGlobals.luxSubdomainSuffix) -> {
+                val subdomain = domain.substringBefore(SiteGlobals.luxSubdomainSuffix)
                 val model = subdomains.find {
                     it.subdomain.equals(subdomain, ignoreCase = true)
                 }

--- a/site/src/jsMain/kotlin/domains/lux/core/model/subdomain/Subdomain.kt
+++ b/site/src/jsMain/kotlin/domains/lux/core/model/subdomain/Subdomain.kt
@@ -1,8 +1,12 @@
 package energy.lux.frontend.domains.lux.core.model.subdomain
 
 import androidx.compose.runtime.Composable
+import energy.lux.frontend.pages.SiteGlobals
 
 interface Subdomain {
     val subdomain: String
     val subdomainComponent: @Composable () -> Unit
+
+    val fullDomain: String
+        get() = subdomain + SiteGlobals.luxSubdomainSuffix
 }

--- a/site/src/jsMain/kotlin/domains/lux/core/model/subdomain/SubdomainTwinModel.kt
+++ b/site/src/jsMain/kotlin/domains/lux/core/model/subdomain/SubdomainTwinModel.kt
@@ -2,7 +2,6 @@ package energy.lux.frontend.domains.lux.core.model.subdomain
 
 import energy.lux.frontend.core.services.localization.localizedUrl
 import energy.lux.frontend.domains.lux.core.TwinModelCard
-import energy.lux.frontend.pages.SiteGlobals
 
 
 /**
@@ -11,5 +10,5 @@ import energy.lux.frontend.pages.SiteGlobals
  */
 sealed interface SubdomainTwinModel : Subdomain, TwinModelCard {
     override val url: String
-        get() = localizedUrl("${subdomain}.${SiteGlobals.LUX_DOMAIN}", "/")
+        get() = localizedUrl(fullDomain, "/")
 }

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/drechtsteden/DrechtstedenTwinModel.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/drechtsteden/DrechtstedenTwinModel.kt
@@ -11,10 +11,9 @@ import energy.lux.frontend.domains.lux.core.model.subdomain.PrivateSubdomainMode
 import energy.lux.frontend.domains.lux.core.toTwinModelCardItem
 import energy.lux.frontend.domains.lux.pages.application_fields.DrechtstedenProjectArea
 import energy.lux.frontend.domains.lux.pages.application_fields.LuxApplicationArea
-import energy.lux.frontend.pages.SiteGlobals
 import kotlin.uuid.Uuid
 
-private val drechtstedenFullDomain = "${PrivateSubdomainModel.DRECHTSTEDEN.subdomain}.${SiteGlobals.LUX_DOMAIN}"
+private val drechtstedenFullDomain = PrivateSubdomainModel.DRECHTSTEDEN.fullDomain
 
 sealed interface DrechtstedenTwinModelBase : Route, TwinModelCard {
     val projectPath: String

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/oss/OssTwinModel.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/oss/OssTwinModel.kt
@@ -15,10 +15,9 @@ import energy.lux.frontend.domains.lux.subdomains.private_subdomains.oss.pages.E
 import energy.lux.frontend.domains.lux.subdomains.private_subdomains.oss.pages.Euterpepark
 import energy.lux.frontend.domains.lux.subdomains.private_subdomains.oss.pages.Moleneind
 import energy.lux.frontend.domains.lux.subdomains.private_subdomains.oss.pages.VorstenGrafDonk
-import energy.lux.frontend.pages.SiteGlobals
 import kotlin.uuid.Uuid
 
-private val ossDomain = "${PrivateSubdomainModel.OSS.subdomain}.${SiteGlobals.LUX_DOMAIN}"
+private val ossDomain = PrivateSubdomainModel.OSS.fullDomain
 
 data class OssTwinModel(
     override val label: LocalizedText,

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/regiofoodvalley/regiofoodvalleyNavMenu.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/regiofoodvalley/regiofoodvalleyNavMenu.kt
@@ -3,14 +3,10 @@ package energy.lux.frontend.domains.lux.subdomains.private_subdomains.regiofoodv
 import energy.lux.frontend.core.models.MenuItem
 import energy.lux.frontend.core.models.RoutedMenuItem
 import energy.lux.frontend.core.services.localization.LocalizedText
-import energy.lux.frontend.domains.lux.core.model.subdomain.PrivateSubdomainModel
 import energy.lux.frontend.domains.lux.subdomains.private_subdomains.regiofoodvalley.pages.RegioFoodValleyBusinessParksPage
 import energy.lux.frontend.domains.lux.subdomains.private_subdomains.regiofoodvalley.pages.RegioFoodValleyHomePage
 import energy.lux.frontend.domains.lux.subdomains.private_subdomains.regiofoodvalley.pages.RegioFoodValleyNeighbourhoodsPage
 import energy.lux.frontend.domains.lux.subdomains.private_subdomains.regiofoodvalley.pages.RegioFoodValleyRegioPage
-import energy.lux.frontend.pages.SiteGlobals
-
-val regiofoodvalleyDomain = "${PrivateSubdomainModel.REGIOFOODVALLEY}.${SiteGlobals.LUX_DOMAIN}"
 
 val regiofoodvalleyHomeMenuItem = MenuItem.Simple(
     RoutedMenuItem(

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/public_subdomains/brabant/components/BrabantTwinModel.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/public_subdomains/brabant/components/BrabantTwinModel.kt
@@ -11,11 +11,7 @@ import energy.lux.frontend.domains.lux.core.model.subdomain.brabant
 import energy.lux.frontend.domains.lux.pages.application_fields.ApplicationArea
 import energy.lux.frontend.domains.lux.subdomains.public_subdomains.brabant.pages.BrabantNeighbourhood
 import energy.lux.frontend.domains.lux.subdomains.public_subdomains.brabant.pages.BrabantProvince
-import energy.lux.frontend.pages.SiteGlobals
 import kotlin.uuid.Uuid
-
-
-private val brabantDomain = "${brabant.subdomain}.${SiteGlobals.LUX_DOMAIN}"
 
 data class BrabantTwinModel(
     override val applicationArea: ApplicationArea = brabant.applicationArea,
@@ -23,7 +19,7 @@ data class BrabantTwinModel(
     override val label: LocalizedText,
     override val modelId: Uuid,
     override val path: String = label.en.asNavLinkPath(),
-    override val url: String = localizedUrl(brabantDomain, path),
+    override val url: String = localizedUrl(brabant.fullDomain, path),
     override val pageComponent: PageComponent,
 ) : TwinModelCard, Route
 

--- a/site/src/jsMain/kotlin/domains/lux/subdomains/public_subdomains/empowered/empoweredMenuItems.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/public_subdomains/empowered/empoweredMenuItems.kt
@@ -7,9 +7,8 @@ import energy.lux.frontend.domains.lux.core.model.subdomain.empowered
 import energy.lux.frontend.domains.lux.subdomains.public_subdomains.empowered.pages.Bronckhorst
 import energy.lux.frontend.domains.lux.subdomains.public_subdomains.empowered.pages.NijmegenHengstdal
 import energy.lux.frontend.domains.lux.subdomains.public_subdomains.empowered.pages.empowered.EmpoweredIndex
-import energy.lux.frontend.pages.SiteGlobals
 
-val empoweredDomain = "${empowered.subdomain}.${SiteGlobals.LUX_DOMAIN}"
+val empoweredDomain = empowered.fullDomain
 val empoweredHomeMenuItem = MenuItem.Simple(
     RoutedMenuItem(
         path = "/", label = LocalizedText("EmPowerED", "EmPowerED"),

--- a/site/src/jsMain/kotlin/pages/DomainRoutes.kt
+++ b/site/src/jsMain/kotlin/pages/DomainRoutes.kt
@@ -12,13 +12,31 @@ import kotlinx.browser.window
 object SiteGlobals {
     val LUX_DOMAIN: String = AppGlobals.getValue("LUX_DOMAIN")
     val ZENMO_DOMAIN: String = AppGlobals.getValue("ZENMO_DOMAIN")
+
+    /**
+     * In the production and test environments the LUX project-specific
+     * subdomains are separated using a dot (.).
+     * The projects go under [project].lux.energy.
+     *
+     * For pull requests, however, we use a dash (-).
+     * The projects go under [project]-[build-number].pr.lux.energy.
+     * This is so that we can use the *.pr.lux.energy. wildcard certificate
+     * for all pull requests.
+     *
+     * Example settings to deploy a pull request:
+     *
+     * LUX_DOMAIN=123.pr.lux.energy
+     * SUBDOMAIN_SEPARATOR=-
+     */
+    val SUBDOMAIN_SEPARATOR: String = AppGlobals.getValue("SUBDOMAIN_SEPARATOR")
+    val luxSubdomainSuffix = SUBDOMAIN_SEPARATOR + LUX_DOMAIN
 }
 
 @Page("{...catch-all}")
 @Composable
 fun DomainRoutes() {
     val domain = window.location.host
-    val luxSubdomainSuffix = ".${SiteGlobals.LUX_DOMAIN}"
+    val luxSubdomainSuffix = SiteGlobals.luxSubdomainSuffix
 
     when {
         domain == SiteGlobals.LUX_DOMAIN -> LuxDomainLoader()

--- a/site/src/jsMain/kotlin/theme/SiteTheme.kt
+++ b/site/src/jsMain/kotlin/theme/SiteTheme.kt
@@ -80,7 +80,7 @@ data class SitePalette(
         private val domain = window.location.host
         val light = when (domain) {
             SiteGlobals.ZENMO_DOMAIN -> zenmoColorPalette
-            "${brabant.subdomain}.${SiteGlobals.LUX_DOMAIN}" -> brabantColorPalette
+            brabant.fullDomain -> brabantColorPalette
             else -> luxColorPalette
         }
     }


### PR DESCRIPTION
See comment in SiteGlobals for details.

If you want to test this locally, set SUBDOMAIN_SEPARATOR to "-" and check that the site still works.