### PR TITLE
fix reversed ProjectRowCard not applying in test environment

### DIFF
--- a/site/src/jsMain/kotlin/domains/zenmo/pages/projects/ProjectRowCard.kt
+++ b/site/src/jsMain/kotlin/domains/zenmo/pages/projects/ProjectRowCard.kt
@@ -8,7 +8,6 @@ import com.varabyte.kobweb.compose.foundation.layout.Row
 import com.varabyte.kobweb.compose.ui.Alignment
 import com.varabyte.kobweb.compose.ui.Modifier
 import com.varabyte.kobweb.compose.ui.modifiers.*
-import com.varabyte.kobweb.compose.ui.thenIf
 import com.varabyte.kobweb.compose.ui.toAttrs
 import com.varabyte.kobweb.silk.components.graphics.Image
 import com.varabyte.kobweb.silk.components.icons.mdi.MdiNorthEast
@@ -31,12 +30,10 @@ import org.jetbrains.compose.web.dom.Span
 
 @Composable
 fun ProjectRowCard(item: ZenmoProject, reversed: Boolean = false) {
+    val projectRowStyle = if (reversed) ProjectRowReverseStyle else ResponsiveFlexStyle
     Div(
-        ResponsiveFlexStyle.toModifier()
+        projectRowStyle.toModifier()
             .gap(2.cssRem)
-            .thenIf(
-                reversed, ProjectRowReverseStyle.toModifier()
-            )
             .toAttrs()
     ) {
         Image(

--- a/site/src/jsMain/kotlin/domains/zenmo/pages/projects/ProjectsStyles.kt
+++ b/site/src/jsMain/kotlin/domains/zenmo/pages/projects/ProjectsStyles.kt
@@ -1,12 +1,15 @@
 package energy.lux.frontend.domains.zenmo.pages.projects
 
+import com.varabyte.kobweb.compose.css.AlignItems
 import com.varabyte.kobweb.compose.css.ObjectFit
 import com.varabyte.kobweb.compose.css.Overflow
 import com.varabyte.kobweb.compose.ui.Modifier
 import com.varabyte.kobweb.compose.ui.modifiers.*
 import com.varabyte.kobweb.silk.style.CssStyle
 import com.varabyte.kobweb.silk.style.breakpoint.Breakpoint
+import energy.lux.frontend.domains.lux.styles.responsiveGap
 import energy.lux.frontend.theme.SitePalette
+import org.jetbrains.compose.web.css.DisplayStyle
 import org.jetbrains.compose.web.css.FlexDirection
 import org.jetbrains.compose.web.css.percent
 import org.jetbrains.compose.web.css.px
@@ -14,7 +17,11 @@ import org.jetbrains.compose.web.css.px
 val ProjectRowReverseStyle = CssStyle {
     base {
         Modifier
+            .fillMaxWidth()
+            .display(DisplayStyle.Flex)
             .flexDirection(FlexDirection.Column)
+            .alignItems(AlignItems.Center)
+            .responsiveGap()
     }
     Breakpoint.LG {
         Modifier


### PR DESCRIPTION
Use a dedicated CssStyle for the reversed layout so the flex-direction is resolved at the CSS level rather than at runtime, which was not being applied correctly in the test environment.