### PR TITLE
fix: correct Dutch grammar in Drechtsteden access text

### DIFF
--- a/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/drechtsteden/pages/DrechtstedenHomePage.kt
+++ b/site/src/jsMain/kotlin/domains/lux/subdomains/private_subdomains/drechtsteden/pages/DrechtstedenHomePage.kt
@@ -101,7 +101,7 @@ fun DrechtstedenHomePage() {
                     Br { }
                     LangText(
                         en = "If you want access send an email to ",
-                        nl = "als je toegang wilt stuur dan een email to "
+                        nl = "als je toegang wilt sturen dan een email naar "
                     )
                     InlineLink(
                         destinationUrl = "mailto:${modeller.email}",


### PR DESCRIPTION
## Summary

Correct Dutch grammar typo in :

- **Before:** 
- **After:**  

Changes:
-  →  (infinitive form after modal verb )
-  →  (correct preposition)

## Issue

Closes #676

## Testing

- [x] Build passes (Kotlin syntax verified)
- [x] Single commit
- [x] No unrelated changes